### PR TITLE
Update - EndpointUptime e EndpointDowntime 

### DIFF
--- a/documentation/source/swagger/parts/_open_banking_fase1_apis_part.yml
+++ b/documentation/source/swagger/parts/_open_banking_fase1_apis_part.yml
@@ -452,11 +452,12 @@ components:
             endpoints:
               $ref: '#/components/schemas/EndpointDowntime'
     EndpointUptime:
-      type: object
+      type: array
       description: Tempos de uptime por endpoint.
-      required:
-        - url
-        - uptimeRate
+      items:
+        required:
+          - url
+          - uptimeRate
       properties:
         url:
           type: string
@@ -465,11 +466,12 @@ components:
           type: string
           description: Taxa de disponibilidade do endpoint.
     EndpointDowntime:
-      type: object
+      type: array
       description: Tempos de downtime por endpoint.
-      required:
-        - url
-        - partialDowntime
+      items:
+        required:
+          - url
+          - partialDowntime
       properties:
         url:
           type: string

--- a/documentation/source/swagger/swagger_open_banking_fase1_apis.yml
+++ b/documentation/source/swagger/swagger_open_banking_fase1_apis.yml
@@ -448,11 +448,12 @@ components:
             endpoints:
               $ref: '#/components/schemas/EndpointDowntime'
     EndpointUptime:
-      type: object
+      type: array
       description: Tempos de uptime por endpoint.
-      required:
-        - url
-        - uptimeRate
+      items:
+        required:
+          - url
+          - uptimeRate
       properties:
         url:
           type: string
@@ -461,11 +462,12 @@ components:
           type: string
           description: Taxa de disponibilidade do endpoint.
     EndpointDowntime:
-      type: object
+      type: array
       description: Tempos de downtime por endpoint.
-      required:
-        - url
-        - partialDowntime
+      items:
+        required:
+          - url
+          - partialDowntime
       properties:
         url:
           type: string


### PR DESCRIPTION
EndpointUptime e EndpointDowntime deve ser arrays com todas as URLs disponivels

Exemplos em produção;

https://analytics.mobilidade.caixa.gov.br/analytics/ws/open-banking/admin/v1/metrics
https://btgpactual.openbanking.btgpactual.com/open-banking/admin/v1/metrics

