### PR TITLE
Correção  /data/dueDate estava sem o tipo de dado json em financingsG…

### DIFF
--- a/documentation/source/swagger/parts/schemas/financings_apis/FinancingsContract.yaml
+++ b/documentation/source/swagger/parts/schemas/financings_apis/FinancingsContract.yaml
@@ -92,6 +92,7 @@ properties:
       Todos os valores monetários informados estão representados com a moeda vigente do Brasil
     example: "BRL"
   dueDate:
+    type: string
     format: date
     maxLength: 10
     pattern: ^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])$


### PR DESCRIPTION
…etContractsContractId Financings, que é string.