### PR TITLE
Fix payeeMCC and chargeNumber types + format

### DIFF
--- a/documentation/source/swagger/parts/schemas/credit_cards_apis/CreditCardAccountsTransaction.yaml
+++ b/documentation/source/swagger/parts/schemas/credit_cards_apis/CreditCardAccountsTransaction.yaml
@@ -76,8 +76,8 @@ properties:
     example: PARCELA_1
     description: Identificador da parcela que está sendo informada. Campo de livre preenchimento
   chargeNumber:
-    type: number
-    format: integer
+    type: integer
+    format: int32
     nullable: true
     maxLength: 2
     example: 3
@@ -121,8 +121,8 @@ properties:
     example: '2021-05-21'
     description: Data em que a transação foi inserida na fatura
   payeeMCC:
-    type: number
-    format: integer
+    type: integer
+    format: int32
     maxLength: 4
     nullable: true
     example: 5137


### PR DESCRIPTION
The fields **payeeMCC** and **chargeNumber** from CreditCardAccountsTransaction were incompatible with OpenAPI 3.0.0 spec (https://swagger.io/specification/#data-types), fixed.
