### PR TITLE
replace Authorisation with Authorization

### DIFF
--- a/documentation/source/dictionary/resourcesGetResources_v1.csv
+++ b/documentation/source/dictionary/resourcesGetResources_v1.csv
@@ -20,7 +20,7 @@ INVOICE_FINANCING";1;1;"";Não permitido;string;ACCOUNT
 Available - Disponível
 Unavailable - Indisponível
 Temporarily Unavailable - Temporariamente Indisponível
-Pending Authorisation - Pendente de Autorização";Texto;;Obrigatório;;"AVAILABLE 
+Pending Authorization - Pendente de Autorização";Texto;;Obrigatório;;"AVAILABLE 
 UNAVAILABLE 
 TEMPORARILY_UNAVAILABLE 
 PENDING_AUTHORISATION";1;1;"";Não permitido;string;AVAILABLE

--- a/documentation/source/includes/_diretrizes_tecnicas_diretorio.md.erb
+++ b/documentation/source/includes/_diretrizes_tecnicas_diretorio.md.erb
@@ -12,7 +12,7 @@ O documento está estruturado nas seguintes seções:
 1. Introdução
 2. Registrando um usuário no Diretório
 3. Acessando uma Organisation
-4. Cadastrando um Authorisation Server
+4. Cadastrando um Authorization Server
 5. Cadastrando Recursos de uma API
 6. Criando um Software Statements
 7. Criando uma solicitação de Assinatura de Certificado (CSR) em Sandbox

--- a/documentation/source/includes/_especificacoes_apis_diretorio_e_service_desk.md.erb
+++ b/documentation/source/includes/_especificacoes_apis_diretorio_e_service_desk.md.erb
@@ -17,16 +17,16 @@ As funcionalidades previamente liberadas para acesso são:
 
 * Organisations
 * References - Authority
-* References - Authorisation Domain
-* References - Authorisation Domain Role
-* References - Authority Authorisation Domain
+* References - Authorization Domain
+* References - Authorization Domain Role
+* References - Authority Authorization Domain
 * Organisation Authority Domain Claims
 * Organisation Authority Claims
-* Organisation Authority Claims Authorisations
+* Organisation Authority Claims Authorizations
 * Contacts
-* Authorisation Servers
-* Authorisation Servers - API Resources
-* Authorisation Servers - API Discovery Endpoints
+* Authorization Servers
+* Authorization Servers - API Resources
+* Authorization Servers - API Discovery Endpoints
 * Software Statements
 * Software Statement Authority Claims
 * Software Statement Certificates

--- a/documentation/source/includes/_participant.md.erb
+++ b/documentation/source/includes/_participant.md.erb
@@ -11,15 +11,15 @@ Os campos que contêm informações relevantes para descoberta dos *endpoints* p
 |Campo                                               |  Descrição                                       |
 |:---------------------------------------------------|:-------------------------------------------------|
 |**OrganisationDetails.OrganisationId**              |O Identificador do participante                   |
-|**AuthorisationServers.CustomerFriendlyName**       |Nome da marca                                     |
+|**AuthorizationServers.CustomerFriendlyName**       |Nome da marca                                     |
 |**OrganisationDetails.RegistrationNumber**          |CNPJ                                              |
 |**OrganisationDetails.RegisteredName**              |Razão Social                                      |
 |**OrgDomainRoleClaim.Role**                         |Papel junto ao Open Banking                       |
 |**OrgDomainRoleClaim.Status**                       |Status do papel                                   |
-|**AuthorisationServers.APIResources.APIFamilyTipe** |URL das APIs                                      |
-|**AuthorisationServers.APIResources.APIVersion**    |                                                  |
-|**AuthorisationServers.APIResources.APIEndPoint**   |                                                  |
-|**AuthorisationServers.DeveloperPortalURI**         |URL da documentação sobre a API do participante   |
+|**AuthorizationServers.APIResources.APIFamilyTipe** |URL das APIs                                      |
+|**AuthorizationServers.APIResources.APIVersion**    |                                                  |
+|**AuthorizationServers.APIResources.APIEndPoint**   |                                                  |
+|**AuthorizationServers.DeveloperPortalURI**         |URL da documentação sobre a API do participante   |
 
 A especificação do arquivo de participantes pode ser acessada <a href="swagger/swagger_participants.yaml" target="_blank">aqui</a>.
 

--- a/documentation/source/includes/partials_open_banking/_open_banking_fase2_apis.md.erb
+++ b/documentation/source/includes/partials_open_banking/_open_banking_fase2_apis.md.erb
@@ -7444,7 +7444,7 @@ Titular, pessoa jurídica a quem se referem os dados que são objeto de comparti
 |data|[object]|true|Lista de recursos e seus respectivos status.|
 |» resourceId|string|false|Identifica o recurso reportado pelo participante do Open Banking, no caso de:<br>Contas de depósito à vista, de poupança ou de pagamento pré-paga : corresponde ao accountId;<br>Conta de pagamento pós-paga: corresponde ao creditCardAccountId;<br>Empréstimos, Financiamentos, Direitos creditórios descontados e Adiantamento a depositantes: corresponde ao contractId.|
 |» type|string|true|Tipo de recurso (vide Enum):<br>Account - Conta de depósito à vista, poupança ou pagamento pré-paga<br>Credit Card Account - Conta de pagamento pós-paga (Cartão de Crédito)<br>Loan - Empréstimo<br>Financing - Financiamento<br>Unarranged Account Overdraft - Cheque Especial<br>Invoice Financing - Financiamento de Fatura|
-|» status|string|true|Tipo de status de recurso (vide Enum):<br>Available - Disponível<br>Unavailable - Indisponível<br>Temporarily Unavailable - Temporariamente Indisponível<br>Pending Authorisation - Pendente de Autorização|
+|» status|string|true|Tipo de status de recurso (vide Enum):<br>Available - Disponível<br>Unavailable - Indisponível<br>Temporarily Unavailable - Temporariamente Indisponível<br>Pending Authorization - Pendente de Autorização|
 |links|[Links](#schemalinks)|true|Referências para outros recusos da API requisitada.|
 |meta|[Meta](#schemameta)|true|Meta informações referente a API requisitada.|
 

--- a/documentation/source/includes/partials_open_banking/_open_banking_fase3_apis.md.erb
+++ b/documentation/source/includes/partials_open_banking/_open_banking_fase3_apis.md.erb
@@ -1169,10 +1169,10 @@ TRAN - TransactingAccount - Conta de Pagamento pré-paga.
 |**|SVGS|
 |**|TRAN|
 
-<h2 id="tocS_EnumAuthorisationStatusType">EnumAuthorisationStatusType</h2>
+<h2 id="tocS_EnumAuthorizationStatusType">EnumAuthorizationStatusType</h2>
 
 <a id="schemaenumauthorisationstatustype"></a>
-<a id="schema_EnumAuthorisationStatusType"></a>
+<a id="schema_EnumAuthorizationStatusType"></a>
 <a id="tocSenumauthorisationstatustype"></a>
 <a id="tocsenumauthorisationstatustype"></a>
 

--- a/documentation/source/includes/partials_security_guide/_consent_flow.md.erb
+++ b/documentation/source/includes/partials_security_guide/_consent_flow.md.erb
@@ -88,7 +88,7 @@ Host: as.banco.exemplo
 
 O consentimento dado pelo usuário define quais informações a aplicação da instituição receptora terá acesso, mas não possui a granularidade de quais unidades de produto estão disponíveis para acesso. Essa informação cabe exclusivamente a instituição transmissora de dados. O seguinte exemplo demonstra o escopo de informações que o consentimento garante (Exemplos de codigo ao lado):
 
-1. O usuário deseja compartilhar as informações de suas contas pré-pagas. Após o fluxo do *front-end*, a aplicação do receptor deve pedir um *token* ao *Authorisation Server* com o *scope* "*consents*".
+1. O usuário deseja compartilhar as informações de suas contas pré-pagas. Após o fluxo do *front-end*, a aplicação do receptor deve pedir um *token* ao *Authorization Server* com o *scope* "*consents*".
 
 2. Com o *token*, deve-se fazer uma requisição para a API de *Consents*, utilizando este *token* no *header*.
 

--- a/documentation/source/swagger/parts/_open_banking_fase3_apis_part.yml
+++ b/documentation/source/swagger/parts/_open_banking_fase3_apis_part.yml
@@ -278,8 +278,8 @@ components:
       $ref: ./schemas/business_commons/DebtorAccount.yaml
     EnumAccountPaymentsType:
       $ref: ./schemas/enum/EnumAccountPaymentsType.yaml
-    EnumAuthorisationStatusType:
-      $ref: ./schemas/enum/EnumAuthorisationStatusType.yaml
+    EnumAuthorizationStatusType:
+      $ref: ./schemas/enum/EnumAuthorizationStatusType.yaml
     EnumPaymentPersonType:
       $ref: ./schemas/enum/EnumPaymentPersonType.yaml
     EnumPaymentType:

--- a/documentation/source/swagger/parts/schemas/consents_apis/ResponseConsent.yaml
+++ b/documentation/source/swagger/parts/schemas/consents_apis/ResponseConsent.yaml
@@ -36,10 +36,10 @@ properties:
         description: "Estado atual do consentimento cadastrado."
         type: "string"
         enum:
-          - "AUTHORISED"
-          - "AWAITING_AUTHORISATION"
+          - "AUTHORIZED"
+          - "AWAITING_AUTHORIZATION"
           - "REJECTED"
-        example: "AWAITING_AUTHORISATION"
+        example: "AWAITING_AUTHORIZATION"
       statusUpdateDateTime:
         description: "Data e hora em que o recurso foi atualizado. Uma string com data e hora conforme especificação RFC-3339, sempre com a utilização de timezone UTC(UTC time format)."
         type: "string"

--- a/documentation/source/swagger/parts/schemas/enum/EnumAuthorizationStatusType.yaml
+++ b/documentation/source/swagger/parts/schemas/enum/EnumAuthorizationStatusType.yaml
@@ -1,18 +1,18 @@
 type: string
 maxLength: 22
 enum:
-  - AWAITING_AUTHORISATION
-  - AUTHORISED
+  - AWAITING_AUTHORIZATION
+  - AUTHORIZED
   - REJECTED
   - CONSUMED
-example: AWAITING_AUTHORISATION
+example: AWAITING_AUTHORIZATION
 description: |
   Retorna o estado do consentimento, o qual no momento de sua criação será AWAITING_AUTHORISATION.
   Este estado será alterado depois da autorização do consentimento na detentora da conta do pagador (Debtor) para AUTHORISED ou REJECTED. 
   O consentimento fica no estado CONSUMED após ocorrer a iniciação do pagamento referente ao consentimento.  
   Em caso de consentimento expirado a detentora deverá retornar o status REJECTED.  
   Estados possíveis:  
-  AWAITING_AUTHORISATION - Aguardando autorização  
+  AWAITING_AUTHORIZATION - Aguardando autorização
   AUTHORISED - Autorizado   
   REJECTED - Rejeitado  
-  CONSUMED - Consumido 
+  CONSUMED - Consumido

--- a/documentation/source/swagger/parts/schemas/enum/EnumResourceStatusType.yaml
+++ b/documentation/source/swagger/parts/schemas/enum/EnumResourceStatusType.yaml
@@ -3,11 +3,11 @@ enum:
   - AVAILABLE
   - UNAVAILABLE
   - TEMPORARILY_UNAVAILABLE
-  - PENDING_AUTHORISATION
+  - PENDING_AUTHORIZATION
 description: |
   Tipo de status de recurso (vide Enum):
   Available - Disponível
   Unavailable - Indisponível
   Temporarily Unavailable - Temporariamente Indisponível
-  Pending Authorisation - Pendente de Autorização
+  Pending Authorization - Pendente de Autorização
 example: 'AVAILABLE'

--- a/documentation/source/swagger/parts/schemas/payments_apis/ResponsePaymentConsentData.yaml
+++ b/documentation/source/swagger/parts/schemas/payments_apis/ResponsePaymentConsentData.yaml
@@ -33,7 +33,7 @@ properties:
     description: |
        Data e hora em que o recurso foi atualizado. Uma string com data e hora conforme especificação RFC-3339, sempre com a utilização de timezone UTC(UTC time format).
   status:
-    $ref: '../enum/EnumAuthorisationStatusType.yaml'
+    $ref: '../enum/EnumAuthorizationStatusType.yaml'
   creditor:
     $ref: ../payments_apis/PaymentIdentification.yaml
   payment:

--- a/documentation/source/swagger/swagger_open_banking_fase2_apis.yml
+++ b/documentation/source/swagger/swagger_open_banking_fase2_apis.yml
@@ -3213,7 +3213,7 @@ components:
                   Available - Disponível
                   Unavailable - Indisponível
                   Temporarily Unavailable - Temporariamente Indisponível
-                  Pending Authorisation - Pendente de Autorização
+                  Pending Authorization - Pendente de Autorização
                 example: AVAILABLE
             additionalProperties: false
           minItems: 1

--- a/documentation/source/swagger/swagger_open_banking_fase3_apis.yml
+++ b/documentation/source/swagger/swagger_open_banking_fase3_apis.yml
@@ -444,7 +444,7 @@ components:
         SLRY - Salary - Conta-Salário.  
         SVGS - Savings - Conta de Poupança.  
         TRAN - TransactingAccount - Conta de Pagamento pré-paga.
-    EnumAuthorisationStatusType:
+    EnumAuthorizationStatusType:
       type: string
       maxLength: 22
       enum:
@@ -921,7 +921,7 @@ components:
               description: |
                 Data e hora em que o recurso foi atualizado. Uma string com data e hora conforme especificação RFC-3339, sempre com a utilização de timezone UTC(UTC time format).
             status:
-              $ref: '#/components/schemas/EnumAuthorisationStatusType'
+              $ref: '#/components/schemas/EnumAuthorizationStatusType'
             creditor:
               $ref: '#/components/schemas/Identification'
             payment:

--- a/documentation/source/swagger/swagger_participants.yaml
+++ b/documentation/source/swagger/swagger_participants.yaml
@@ -37,13 +37,13 @@ components:
       in: query
       schema:
         $ref: '#/components/schemas/PageableRequest'
-    AuthorisationServerId:
-      name: AuthorisationServerId
+    AuthorizationServerId:
+      name: AuthorizationServerId
       description: The authorisation server Id
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationServerId'
+        $ref: '#/components/schemas/AuthorizationServerId'
     OrganisationAuthorityClaimId:
       name: OrganisationAuthorityClaimId
       description: The Authority claims ID for an organisation
@@ -51,13 +51,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityClaimId'
-    OrganisationAuthorisationId:
-      name: OrganisationAuthorisationId
+    OrganisationAuthorizationId:
+      name: OrganisationAuthorizationId
       description: The authorisation ID for an organisation's authority claims
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/OrganisationAuthorisationId'
+        $ref: '#/components/schemas/OrganisationAuthorizationId'
     CertificateOrKeyId:
       name: CertificateOrKeyId
       description: The certificate or key Id
@@ -121,27 +121,27 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/UserEmailId'
-    AuthorisationDomainName:
-      name: AuthorisationDomainName
-      description: Authorisation Domain Name. Eg:PSD2
+    AuthorizationDomainName:
+      name: AuthorizationDomainName
+      description: Authorization Domain Name. Eg:PSD2
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainName'
-    AuthorisationDomainRoleName:
-      name: AuthorisationDomainRoleName
-      description: Authorisation Domain Role Name. Eg:TPP
+        $ref: '#/components/schemas/AuthorizationDomainName'
+    AuthorizationDomainRoleName:
+      name: AuthorizationDomainRoleName
+      description: Authorization Domain Role Name. Eg:TPP
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainRoleName'
-    AuthorityAuthorisationDomainId:
-      name: AuthorityAuthorisationDomainId
-      description: ID of the Authority mapped with Authorisation Domain
+        $ref: '#/components/schemas/AuthorizationDomainRoleName'
+    AuthorityAuthorizationDomainId:
+      name: AuthorityAuthorizationDomainId
+      description: ID of the Authority mapped with Authorization Domain
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomainId'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomainId'
     OrganisationAuthorityDomainClaimId:
       name: OrganisationAuthorityDomainClaimId
       description: Organisation Authority Domain Claim Id
@@ -149,13 +149,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityDomainClaimId'
-    AuthorisationDomainUserId:
-      name: AuthorisationDomainUserId
+    AuthorizationDomainUserId:
+      name: AuthorizationDomainUserId
       description: Unique record Id to identify Domain User
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainUserId'
+        $ref: '#/components/schemas/AuthorizationDomainUserId'
     TnCId:
       name: TnCId
       description: Terms and Conditions unique identifier
@@ -202,13 +202,13 @@ components:
           schema:
             $ref: '#/components/schemas/AmendCertificateRequest'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       description: Properties to create/update authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServerRequest'
+            $ref: '#/components/schemas/AuthorizationServerRequest'
 
     OrganisationAuthorityClaimRequest:
       description: Properties to create/update authority claims
@@ -227,13 +227,13 @@ components:
             $ref: '#/components/schemas/UserUpdateRequest'
 
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       description: Properties to update/retrieve authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisationRequest'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizationRequest'
     ContactRequest:
       description: Properties to update contacts
       required: true
@@ -375,40 +375,40 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUserCreationRequest'
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       description: Admin user creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserCreateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserCreateRequest'
 
-    AuthorisationDomainRequest:
-      description: Authorisation Domain creation request
+    AuthorizationDomainRequest:
+      description: Authorization Domain creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRequest'
 
-    AuthorisationDomainRoleRequest:
-      description: Authorisation Domain Role creation request
+    AuthorizationDomainRoleRequest:
+      description: Authorization Domain Role creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoleRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRoleRequest'
 
-    AuthorityAuthorisationDomainRequest:
-      description: Authority Authorisation Domain mapping request
+    AuthorityAuthorizationDomainRequest:
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomainRequest'
 
     OrganisationAuthorityDomainClaimRequest:
-      description: Authority Authorisation Domain mapping request
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
@@ -467,12 +467,12 @@ components:
           schema:
             $ref: '#/components/schemas/EssSignRequest'
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       description: Request object to update a domain user
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserUpdateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserUpdateRequest'
 
   responses:
     NoContent:
@@ -510,33 +510,33 @@ components:
           schema:
             $ref: '#/components/schemas/OrganisationAuthorityClaim'
 
-    OrganisationAuthorityClaimAuthorisations:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorizations:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisations'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizations'
 
-    OrganisationAuthorityClaimAuthorisation:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorization:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    AuthorisationServers:
+    AuthorizationServers:
       description: All authorisation servers for the org
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServers'
+            $ref: '#/components/schemas/AuthorizationServers'
 
-    AuthorisationServer:
-      description: Authorisation server response
+    AuthorizationServer:
+      description: Authorization server response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServer'
+            $ref: '#/components/schemas/AuthorizationServer'
 
     CertificatesOrKeys:
       description: All certificates for the org
@@ -695,61 +695,61 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUser'
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       description: All users belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUsers'
+            $ref: '#/components/schemas/AuthorizationDomainUsers'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       description: User data belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUser'
+            $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       description: All data of authorisation domains mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomains'
+            $ref: '#/components/schemas/AuthorizationDomains'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       description: Data of an authorisation domain mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomain'
+            $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       description: All roles data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoles'
+            $ref: '#/components/schemas/AuthorizationDomainRoles'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       description: Role data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRole'
+            $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       description: All authority to domain mappings data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomains'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomains'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       description: Authority to domain mapping data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
     OrganisationAuthorityDomainClaims:
       description: All authority to domain mappings data
@@ -815,28 +815,28 @@ components:
             $ref: '#/components/schemas/OrganisationAdminUser'
 
     ApiResources:
-      description: Authorisation server Api Resources response
+      description: Authorization server Api Resources response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResources'
 
     ApiResource:
-      description: Authorisation server Api Resource response
+      description: Authorization server Api Resource response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResource'
 
     ApiDiscoveryEndpoints:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiDiscoveryEndpoints'
 
     ApiDiscoveryEndpoint:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
@@ -923,15 +923,15 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation Domain for the authority
+          description: Authorization Domain for the authority
           maxLength: 30
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
           maxLength: 30
-        Authorisations:
+        Authorizations:
           type: array
           items:
             type: object
@@ -970,12 +970,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Role for the authority
@@ -996,20 +996,20 @@ components:
       required:
         - RegistrationId
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - AuthorityId
         - Role
 
-    OrganisationAuthorityClaimAuthorisations:
+    OrganisationAuthorityClaimAuthorizations:
       type: array
       items:
-        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    OrganisationAuthorityClaimAuthorisation:
+    OrganisationAuthorityClaimAuthorization:
       type: object
       properties:
-        OrganisationAuthorisationId:
-          $ref: '#/components/schemas/OrganisationAuthorisationId'
+        OrganisationAuthorizationId:
+          $ref: '#/components/schemas/OrganisationAuthorizationId'
         OrganisationAuthorityClaimId:
           $ref: '#/components/schemas/OrganisationAuthorityClaimId'
         Status:
@@ -1024,7 +1024,7 @@ components:
           description: Abbreviated states information i.e. GB, IE, NL etc
           maxLength: 10
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       type: object
       properties:
         Status:
@@ -1045,16 +1045,16 @@ components:
         - Status
         - MemberState
 
-    AuthorisationServers:
+    AuthorizationServers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationServer'
+        $ref: '#/components/schemas/AuthorizationServer'
 
-    AuthorisationServer:
+    AuthorizationServer:
       type: object
       properties:
-        AuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        AuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
         OrganisationId:
           $ref: '#/components/schemas/OrganisationId'
         AutoRegistrationSupported:
@@ -1114,10 +1114,10 @@ components:
           type: string
           format: uri
           maxLength: 256
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       type: object
       properties:
         AutoRegistrationSupported:
@@ -1174,8 +1174,8 @@ components:
           type: string
           maxLength: 256
           x-required-message: PayloadSigningCertLocationUri must be provided
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
       required:
         - AutoRegistrationSupported
         - CustomerFriendlyName
@@ -1185,7 +1185,7 @@ components:
         - OpenIDDiscoveryDocument
         - PayloadSigningCertLocationUri
 
-    AuthorisationServerId:
+    AuthorizationServerId:
       type: string
       maxLength: 40
     CertificateOrKeyOrJWT:
@@ -1790,7 +1790,7 @@ components:
       minLength: 1
       maxLength: 40
 
-    OrganisationAuthorisationId:
+    OrganisationAuthorizationId:
       type: string
       description: Unique ID associated with authorisations for organisation's authority claims
       minLength: 1
@@ -1804,7 +1804,7 @@ components:
 
     AuthorityId:
       type: string
-      description: Unique ID associated with the Authorisation reference schema
+      description: Unique ID associated with the Authorization reference schema
       minLength: 1
       maxLength: 40
 
@@ -2014,8 +2014,8 @@ components:
           $ref: '#/components/schemas/Organisation'
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2106,8 +2106,8 @@ components:
           maxLength: 65535
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2389,9 +2389,9 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           maxLength: 30
         Role:
           type: string
@@ -2408,12 +2408,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
@@ -2422,7 +2422,7 @@ components:
           x-required-message: Role must be provided
       required:
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - Role
 
     SoftwareAuthorityClaimUpdateRequest:
@@ -2644,22 +2644,22 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainName:
+    AuthorizationDomainName:
       type: string
-      description: Authorisation Domain Name
+      description: Authorization Domain Name
       maxLength: 30
 
-    AuthorisationDomainRoleName:
+    AuthorizationDomainRoleName:
       type: string
-      description: Authorisation Domain Role Name
+      description: Authorization Domain Role Name
       maxLength: 30
 
-    AuthorityAuthorisationDomainId:
+    AuthorityAuthorizationDomainId:
       type: string
-      description: Mapping ID between Authority and Authorisation Domain
+      description: Mapping ID between Authority and Authorization Domain
       maxLength: 50
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       type: object
       properties:
         Email:
@@ -2667,7 +2667,7 @@ components:
           description: The user email address
           pattern: "^(.{1,}@[^.]{1,}).*"
           x-pattern-message: "EmailAddress must be a valid email"
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
           minLength: 1
@@ -2675,27 +2675,27 @@ components:
           $ref: '#/components/schemas/ContactRoleEnum'
       required:
         - Email
-        - AuthorisationDomainRole
+        - AuthorizationDomainRole
         - ContactRole
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainUser'
+        $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       type: object
       properties:
-        AuthorisationDomainUserId:
+        AuthorizationDomainUserId:
           type: string
           description: Unique record ID
         Email:
           type: string
           description: The user email address
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
           description: The authorisation domain for this user
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
         Status:
@@ -2714,42 +2714,42 @@ components:
             - PBC
             - SBC
 
-    AuthorisationDomainRequest:
+    AuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
           minLength: 2
           x-required-message: The authorisation domain region is mandatory
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
       required:
-        - AuthorisationDomainName
-        - AuthorisationDomainRegion
+        - AuthorizationDomainName
+        - AuthorizationDomainRegion
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomain'
+        $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
         Status:
@@ -2760,42 +2760,42 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainRoleRequest:
+    AuthorizationDomainRoleRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain role name is mandatory
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
       required:
-        - AuthorisationDomainRoleName
-        - AuthorisationDomainName
+        - AuthorizationDomainRoleName
+        - AuthorizationDomainName
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainRole'
+        $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
         Status:
@@ -2806,32 +2806,32 @@ components:
             - Inactive
           default: Active
 
-    AuthorityAuthorisationDomainRequest:
+    AuthorityAuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
       required:
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
           type: string
           description: The GUID of the Authority
-        AuthorityAuthorisationDomainId:
+        AuthorityAuthorizationDomainId:
           type: string
           description: The GUID of the Authority-Domain mapping
         Status:
@@ -2850,7 +2850,7 @@ components:
     OrganisationAuthorityDomainClaimRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
@@ -2865,7 +2865,7 @@ components:
           description: The registration ID
       required:
         - AuthorityId
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
     OrganisationAuthorityDomainClaims:
       type: array
@@ -2878,7 +2878,7 @@ components:
         OrganisationAuthorityDomainClaimId:
           type: string
           description: The unique org authority domain claim ID
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
@@ -2898,7 +2898,7 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainUserId:
+    AuthorizationDomainUserId:
       type: string
       description: Unique record ID to identify Domain user
       maxLength: 50
@@ -3152,9 +3152,9 @@ components:
     DomainRoleDetail:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
         Status:
           $ref: '#/components/schemas/StatusEnum'
@@ -3539,7 +3539,7 @@ components:
       type: string
       description: The envelope id of the ess signing request
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       type: object
       properties:
         Status:

--- a/documentation/source/swagger/swagger_resources_apis.yaml
+++ b/documentation/source/swagger/swagger_resources_apis.yaml
@@ -142,7 +142,7 @@ components:
                   Available - Disponível
                   Unavailable - Indisponível
                   Temporarily Unavailable - Temporariamente Indisponível
-                  Pending Authorisation - Pendente de Autorização
+                  Pending Authorization - Pendente de Autorização
                 example: AVAILABLE
             additionalProperties: false
           minItems: 1

--- a/documentation/source/versions/v1.0.0-rc5.3/index.html
+++ b/documentation/source/versions/v1.0.0-rc5.3/index.html
@@ -24916,7 +24916,7 @@ Espera-se que o detentor dos dados garanta que a medição do tempo de resposta 
 <td style="text-align: left">O Identificador do participante</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.CustomerFriendlyName</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.CustomerFriendlyName</strong></td>
 <td style="text-align: left">Nome da marca</td>
 </tr>
 <tr>
@@ -24936,19 +24936,19 @@ Espera-se que o detentor dos dados garanta que a medição do tempo de resposta 
 <td style="text-align: left">Status do papel</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIFamilyTipe</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIFamilyTipe</strong></td>
 <td style="text-align: left">URL das APIs</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIVersion</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIVersion</strong></td>
 <td style="text-align: left"></td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIEndPoint</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIEndPoint</strong></td>
 <td style="text-align: left"></td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.DeveloperPortalURI</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.DeveloperPortalURI</strong></td>
 <td style="text-align: left">URL da documentação sobre a API do participante</td>
 </tr>
 </tbody></table>

--- a/documentation/source/versions/v1.0.0-rc5.3/swagger/swagger_participants.yaml
+++ b/documentation/source/versions/v1.0.0-rc5.3/swagger/swagger_participants.yaml
@@ -37,13 +37,13 @@ components:
       in: query
       schema:
         $ref: '#/components/schemas/PageableRequest'
-    AuthorisationServerId:
-      name: AuthorisationServerId
+    AuthorizationServerId:
+      name: AuthorizationServerId
       description: The authorisation server Id
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationServerId'
+        $ref: '#/components/schemas/AuthorizationServerId'
     OrganisationAuthorityClaimId:
       name: OrganisationAuthorityClaimId
       description: The Authority claims ID for an organisation
@@ -51,13 +51,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityClaimId'
-    OrganisationAuthorisationId:
-      name: OrganisationAuthorisationId
+    OrganisationAuthorizationId:
+      name: OrganisationAuthorizationId
       description: The authorisation ID for an organisation's authority claims
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/OrganisationAuthorisationId'
+        $ref: '#/components/schemas/OrganisationAuthorizationId'
     CertificateOrKeyId:
       name: CertificateOrKeyId
       description: The certificate or key Id
@@ -121,27 +121,27 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/UserEmailId'
-    AuthorisationDomainName:
-      name: AuthorisationDomainName
-      description: Authorisation Domain Name. Eg:PSD2
+    AuthorizationDomainName:
+      name: AuthorizationDomainName
+      description: Authorization Domain Name. Eg:PSD2
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainName'
-    AuthorisationDomainRoleName:
-      name: AuthorisationDomainRoleName
-      description: Authorisation Domain Role Name. Eg:TPP
+        $ref: '#/components/schemas/AuthorizationDomainName'
+    AuthorizationDomainRoleName:
+      name: AuthorizationDomainRoleName
+      description: Authorization Domain Role Name. Eg:TPP
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainRoleName'
-    AuthorityAuthorisationDomainId:
-      name: AuthorityAuthorisationDomainId
-      description: ID of the Authority mapped with Authorisation Domain
+        $ref: '#/components/schemas/AuthorizationDomainRoleName'
+    AuthorityAuthorizationDomainId:
+      name: AuthorityAuthorizationDomainId
+      description: ID of the Authority mapped with Authorization Domain
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomainId'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomainId'
     OrganisationAuthorityDomainClaimId:
       name: OrganisationAuthorityDomainClaimId
       description: Organisation Authority Domain Claim Id
@@ -149,13 +149,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityDomainClaimId'
-    AuthorisationDomainUserId:
-      name: AuthorisationDomainUserId
+    AuthorizationDomainUserId:
+      name: AuthorizationDomainUserId
       description: Unique record Id to identify Domain User
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainUserId'
+        $ref: '#/components/schemas/AuthorizationDomainUserId'
     TnCId:
       name: TnCId
       description: Terms and Conditions unique identifier
@@ -202,13 +202,13 @@ components:
           schema:
             $ref: '#/components/schemas/AmendCertificateRequest'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       description: Properties to create/update authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServerRequest'
+            $ref: '#/components/schemas/AuthorizationServerRequest'
 
     OrganisationAuthorityClaimRequest:
       description: Properties to create/update authority claims
@@ -227,13 +227,13 @@ components:
             $ref: '#/components/schemas/UserUpdateRequest'
 
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       description: Properties to update/retrieve authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisationRequest'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizationRequest'
     ContactRequest:
       description: Properties to update contacts
       required: true
@@ -375,40 +375,40 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUserCreationRequest'
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       description: Admin user creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserCreateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserCreateRequest'
 
-    AuthorisationDomainRequest:
-      description: Authorisation Domain creation request
+    AuthorizationDomainRequest:
+      description: Authorization Domain creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRequest'
 
-    AuthorisationDomainRoleRequest:
-      description: Authorisation Domain Role creation request
+    AuthorizationDomainRoleRequest:
+      description: Authorization Domain Role creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoleRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRoleRequest'
 
-    AuthorityAuthorisationDomainRequest:
-      description: Authority Authorisation Domain mapping request
+    AuthorityAuthorizationDomainRequest:
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomainRequest'
 
     OrganisationAuthorityDomainClaimRequest:
-      description: Authority Authorisation Domain mapping request
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
@@ -467,12 +467,12 @@ components:
           schema:
             $ref: '#/components/schemas/EssSignRequest'
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       description: Request object to update a domain user
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserUpdateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserUpdateRequest'
 
   responses:
     NoContent:
@@ -510,33 +510,33 @@ components:
           schema:
             $ref: '#/components/schemas/OrganisationAuthorityClaim'
 
-    OrganisationAuthorityClaimAuthorisations:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorizations:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisations'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizations'
 
-    OrganisationAuthorityClaimAuthorisation:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorization:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    AuthorisationServers:
+    AuthorizationServers:
       description: All authorisation servers for the org
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServers'
+            $ref: '#/components/schemas/AuthorizationServers'
 
-    AuthorisationServer:
-      description: Authorisation server response
+    AuthorizationServer:
+      description: Authorization server response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServer'
+            $ref: '#/components/schemas/AuthorizationServer'
 
     CertificatesOrKeys:
       description: All certificates for the org
@@ -695,61 +695,61 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUser'
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       description: All users belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUsers'
+            $ref: '#/components/schemas/AuthorizationDomainUsers'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       description: User data belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUser'
+            $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       description: All data of authorisation domains mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomains'
+            $ref: '#/components/schemas/AuthorizationDomains'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       description: Data of an authorisation domain mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomain'
+            $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       description: All roles data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoles'
+            $ref: '#/components/schemas/AuthorizationDomainRoles'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       description: Role data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRole'
+            $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       description: All authority to domain mappings data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomains'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomains'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       description: Authority to domain mapping data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
     OrganisationAuthorityDomainClaims:
       description: All authority to domain mappings data
@@ -815,28 +815,28 @@ components:
             $ref: '#/components/schemas/OrganisationAdminUser'
 
     ApiResources:
-      description: Authorisation server Api Resources response
+      description: Authorization server Api Resources response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResources'
 
     ApiResource:
-      description: Authorisation server Api Resource response
+      description: Authorization server Api Resource response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResource'
 
     ApiDiscoveryEndpoints:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiDiscoveryEndpoints'
 
     ApiDiscoveryEndpoint:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
@@ -923,15 +923,15 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation Domain for the authority
+          description: Authorization Domain for the authority
           maxLength: 30
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
           maxLength: 30
-        Authorisations:
+        Authorizations:
           type: array
           items:
             type: object
@@ -970,12 +970,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Role for the authority
@@ -996,20 +996,20 @@ components:
       required:
         - RegistrationId
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - AuthorityId
         - Role
 
-    OrganisationAuthorityClaimAuthorisations:
+    OrganisationAuthorityClaimAuthorizations:
       type: array
       items:
-        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    OrganisationAuthorityClaimAuthorisation:
+    OrganisationAuthorityClaimAuthorization:
       type: object
       properties:
-        OrganisationAuthorisationId:
-          $ref: '#/components/schemas/OrganisationAuthorisationId'
+        OrganisationAuthorizationId:
+          $ref: '#/components/schemas/OrganisationAuthorizationId'
         OrganisationAuthorityClaimId:
           $ref: '#/components/schemas/OrganisationAuthorityClaimId'
         Status:
@@ -1024,7 +1024,7 @@ components:
           description: Abbreviated states information i.e. GB, IE, NL etc
           maxLength: 10
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       type: object
       properties:
         Status:
@@ -1045,16 +1045,16 @@ components:
         - Status
         - MemberState
 
-    AuthorisationServers:
+    AuthorizationServers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationServer'
+        $ref: '#/components/schemas/AuthorizationServer'
 
-    AuthorisationServer:
+    AuthorizationServer:
       type: object
       properties:
-        AuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        AuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
         OrganisationId:
           $ref: '#/components/schemas/OrganisationId'
         AutoRegistrationSupported:
@@ -1114,10 +1114,10 @@ components:
           type: string
           format: uri
           maxLength: 256
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       type: object
       properties:
         AutoRegistrationSupported:
@@ -1174,8 +1174,8 @@ components:
           type: string
           maxLength: 256
           x-required-message: PayloadSigningCertLocationUri must be provided
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
       required:
         - AutoRegistrationSupported
         - CustomerFriendlyName
@@ -1185,7 +1185,7 @@ components:
         - OpenIDDiscoveryDocument
         - PayloadSigningCertLocationUri
 
-    AuthorisationServerId:
+    AuthorizationServerId:
       type: string
       maxLength: 40
     CertificateOrKeyOrJWT:
@@ -1790,7 +1790,7 @@ components:
       minLength: 1
       maxLength: 40
 
-    OrganisationAuthorisationId:
+    OrganisationAuthorizationId:
       type: string
       description: Unique ID associated with authorisations for organisation's authority claims
       minLength: 1
@@ -1804,7 +1804,7 @@ components:
 
     AuthorityId:
       type: string
-      description: Unique ID associated with the Authorisation reference schema
+      description: Unique ID associated with the Authorization reference schema
       minLength: 1
       maxLength: 40
 
@@ -2014,8 +2014,8 @@ components:
           $ref: '#/components/schemas/Organisation'
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2106,8 +2106,8 @@ components:
           maxLength: 65535
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2389,9 +2389,9 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           maxLength: 30
         Role:
           type: string
@@ -2408,12 +2408,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
@@ -2422,7 +2422,7 @@ components:
           x-required-message: Role must be provided
       required:
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - Role
 
     SoftwareAuthorityClaimUpdateRequest:
@@ -2644,22 +2644,22 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainName:
+    AuthorizationDomainName:
       type: string
-      description: Authorisation Domain Name
+      description: Authorization Domain Name
       maxLength: 30
 
-    AuthorisationDomainRoleName:
+    AuthorizationDomainRoleName:
       type: string
-      description: Authorisation Domain Role Name
+      description: Authorization Domain Role Name
       maxLength: 30
 
-    AuthorityAuthorisationDomainId:
+    AuthorityAuthorizationDomainId:
       type: string
-      description: Mapping ID between Authority and Authorisation Domain
+      description: Mapping ID between Authority and Authorization Domain
       maxLength: 50
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       type: object
       properties:
         Email:
@@ -2667,7 +2667,7 @@ components:
           description: The user email address
           pattern: "^(.{1,}@[^.]{1,}).*"
           x-pattern-message: "EmailAddress must be a valid email"
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
           minLength: 1
@@ -2675,27 +2675,27 @@ components:
           $ref: '#/components/schemas/ContactRoleEnum'
       required:
         - Email
-        - AuthorisationDomainRole
+        - AuthorizationDomainRole
         - ContactRole
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainUser'
+        $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       type: object
       properties:
-        AuthorisationDomainUserId:
+        AuthorizationDomainUserId:
           type: string
           description: Unique record ID
         Email:
           type: string
           description: The user email address
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
           description: The authorisation domain for this user
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
         Status:
@@ -2714,42 +2714,42 @@ components:
             - PBC
             - SBC
 
-    AuthorisationDomainRequest:
+    AuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
           minLength: 2
           x-required-message: The authorisation domain region is mandatory
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
       required:
-        - AuthorisationDomainName
-        - AuthorisationDomainRegion
+        - AuthorizationDomainName
+        - AuthorizationDomainRegion
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomain'
+        $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
         Status:
@@ -2760,42 +2760,42 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainRoleRequest:
+    AuthorizationDomainRoleRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain role name is mandatory
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
       required:
-        - AuthorisationDomainRoleName
-        - AuthorisationDomainName
+        - AuthorizationDomainRoleName
+        - AuthorizationDomainName
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainRole'
+        $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
         Status:
@@ -2806,32 +2806,32 @@ components:
             - Inactive
           default: Active
 
-    AuthorityAuthorisationDomainRequest:
+    AuthorityAuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
       required:
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
           type: string
           description: The GUID of the Authority
-        AuthorityAuthorisationDomainId:
+        AuthorityAuthorizationDomainId:
           type: string
           description: The GUID of the Authority-Domain mapping
         Status:
@@ -2850,7 +2850,7 @@ components:
     OrganisationAuthorityDomainClaimRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
@@ -2865,7 +2865,7 @@ components:
           description: The registration ID
       required:
         - AuthorityId
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
     OrganisationAuthorityDomainClaims:
       type: array
@@ -2878,7 +2878,7 @@ components:
         OrganisationAuthorityDomainClaimId:
           type: string
           description: The unique org authority domain claim ID
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
@@ -2898,7 +2898,7 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainUserId:
+    AuthorizationDomainUserId:
       type: string
       description: Unique record ID to identify Domain user
       maxLength: 50
@@ -3152,9 +3152,9 @@ components:
     DomainRoleDetail:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
         Status:
           $ref: '#/components/schemas/StatusEnum'
@@ -3539,7 +3539,7 @@ components:
       type: string
       description: The envelope id of the ess signing request
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       type: object
       properties:
         Status:

--- a/documentation/source/versions/v1.0.0-rc6.0/index.html
+++ b/documentation/source/versions/v1.0.0-rc6.0/index.html
@@ -37864,7 +37864,7 @@ This operation does not require authentication
 <td>» status</td>
 <td>string</td>
 <td>true</td>
-<td>Tipo de status de recurso (vide Enum):<br>Available - Disponível<br>Unavailable - Indisponível<br>Temporary Unavailable - Temporariamente Indisponível<br>Pending Authorisation - Pendente de Autorização</td>
+<td>Tipo de status de recurso (vide Enum):<br>Available - Disponível<br>Unavailable - Indisponível<br>Temporary Unavailable - Temporariamente Indisponível<br>Pending Authorization - Pendente de Autorização</td>
 </tr>
 <tr>
 <td>links</td>
@@ -52697,7 +52697,7 @@ Espera-se que o detentor dos dados garanta que a medição do tempo de resposta 
 <td style="text-align: left">O Identificador do participante</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.CustomerFriendlyName</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.CustomerFriendlyName</strong></td>
 <td style="text-align: left">Nome da marca</td>
 </tr>
 <tr>
@@ -52717,19 +52717,19 @@ Espera-se que o detentor dos dados garanta que a medição do tempo de resposta 
 <td style="text-align: left">Status do papel</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIFamilyTipe</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIFamilyTipe</strong></td>
 <td style="text-align: left">URL das APIs</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIVersion</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIVersion</strong></td>
 <td style="text-align: left"></td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIEndPoint</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIEndPoint</strong></td>
 <td style="text-align: left"></td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.DeveloperPortalURI</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.DeveloperPortalURI</strong></td>
 <td style="text-align: left">URL da documentação sobre a API do participante</td>
 </tr>
 </tbody></table>

--- a/documentation/source/versions/v1.0.0-rc6.0/swagger/parts/schemas/enum/EnumResourceStatusType.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.0/swagger/parts/schemas/enum/EnumResourceStatusType.yaml
@@ -9,5 +9,5 @@ description: |
   Available - Disponível
   Unavailable - Indisponível
   Temporary Unavailable - Temporariamente Indisponível
-  Pending Authorisation - Pendente de Autorização
+  Pending Authorization - Pendente de Autorização
 example: 'AVAILABLE'

--- a/documentation/source/versions/v1.0.0-rc6.0/swagger/swagger_open_banking_apis.yml
+++ b/documentation/source/versions/v1.0.0-rc6.0/swagger/swagger_open_banking_apis.yml
@@ -3228,7 +3228,7 @@ components:
                   Available - Disponível
                   Unavailable - Indisponível
                   Temporary Unavailable - Temporariamente Indisponível
-                  Pending Authorisation - Pendente de Autorização
+                  Pending Authorization - Pendente de Autorização
                 example: AVAILABLE
             additionalProperties: false
           minItems: 1

--- a/documentation/source/versions/v1.0.0-rc6.0/swagger/swagger_participants.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.0/swagger/swagger_participants.yaml
@@ -37,13 +37,13 @@ components:
       in: query
       schema:
         $ref: '#/components/schemas/PageableRequest'
-    AuthorisationServerId:
-      name: AuthorisationServerId
+    AuthorizationServerId:
+      name: AuthorizationServerId
       description: The authorisation server Id
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationServerId'
+        $ref: '#/components/schemas/AuthorizationServerId'
     OrganisationAuthorityClaimId:
       name: OrganisationAuthorityClaimId
       description: The Authority claims ID for an organisation
@@ -51,13 +51,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityClaimId'
-    OrganisationAuthorisationId:
-      name: OrganisationAuthorisationId
+    OrganisationAuthorizationId:
+      name: OrganisationAuthorizationId
       description: The authorisation ID for an organisation's authority claims
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/OrganisationAuthorisationId'
+        $ref: '#/components/schemas/OrganisationAuthorizationId'
     CertificateOrKeyId:
       name: CertificateOrKeyId
       description: The certificate or key Id
@@ -121,27 +121,27 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/UserEmailId'
-    AuthorisationDomainName:
-      name: AuthorisationDomainName
-      description: Authorisation Domain Name. Eg:PSD2
+    AuthorizationDomainName:
+      name: AuthorizationDomainName
+      description: Authorization Domain Name. Eg:PSD2
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainName'
-    AuthorisationDomainRoleName:
-      name: AuthorisationDomainRoleName
-      description: Authorisation Domain Role Name. Eg:TPP
+        $ref: '#/components/schemas/AuthorizationDomainName'
+    AuthorizationDomainRoleName:
+      name: AuthorizationDomainRoleName
+      description: Authorization Domain Role Name. Eg:TPP
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainRoleName'
-    AuthorityAuthorisationDomainId:
-      name: AuthorityAuthorisationDomainId
-      description: ID of the Authority mapped with Authorisation Domain
+        $ref: '#/components/schemas/AuthorizationDomainRoleName'
+    AuthorityAuthorizationDomainId:
+      name: AuthorityAuthorizationDomainId
+      description: ID of the Authority mapped with Authorization Domain
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomainId'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomainId'
     OrganisationAuthorityDomainClaimId:
       name: OrganisationAuthorityDomainClaimId
       description: Organisation Authority Domain Claim Id
@@ -149,13 +149,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityDomainClaimId'
-    AuthorisationDomainUserId:
-      name: AuthorisationDomainUserId
+    AuthorizationDomainUserId:
+      name: AuthorizationDomainUserId
       description: Unique record Id to identify Domain User
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainUserId'
+        $ref: '#/components/schemas/AuthorizationDomainUserId'
     TnCId:
       name: TnCId
       description: Terms and Conditions unique identifier
@@ -202,13 +202,13 @@ components:
           schema:
             $ref: '#/components/schemas/AmendCertificateRequest'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       description: Properties to create/update authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServerRequest'
+            $ref: '#/components/schemas/AuthorizationServerRequest'
 
     OrganisationAuthorityClaimRequest:
       description: Properties to create/update authority claims
@@ -227,13 +227,13 @@ components:
             $ref: '#/components/schemas/UserUpdateRequest'
 
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       description: Properties to update/retrieve authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisationRequest'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizationRequest'
     ContactRequest:
       description: Properties to update contacts
       required: true
@@ -375,40 +375,40 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUserCreationRequest'
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       description: Admin user creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserCreateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserCreateRequest'
 
-    AuthorisationDomainRequest:
-      description: Authorisation Domain creation request
+    AuthorizationDomainRequest:
+      description: Authorization Domain creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRequest'
 
-    AuthorisationDomainRoleRequest:
-      description: Authorisation Domain Role creation request
+    AuthorizationDomainRoleRequest:
+      description: Authorization Domain Role creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoleRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRoleRequest'
 
-    AuthorityAuthorisationDomainRequest:
-      description: Authority Authorisation Domain mapping request
+    AuthorityAuthorizationDomainRequest:
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomainRequest'
 
     OrganisationAuthorityDomainClaimRequest:
-      description: Authority Authorisation Domain mapping request
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
@@ -467,12 +467,12 @@ components:
           schema:
             $ref: '#/components/schemas/EssSignRequest'
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       description: Request object to update a domain user
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserUpdateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserUpdateRequest'
 
   responses:
     NoContent:
@@ -510,33 +510,33 @@ components:
           schema:
             $ref: '#/components/schemas/OrganisationAuthorityClaim'
 
-    OrganisationAuthorityClaimAuthorisations:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorizations:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisations'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizations'
 
-    OrganisationAuthorityClaimAuthorisation:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorization:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    AuthorisationServers:
+    AuthorizationServers:
       description: All authorisation servers for the org
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServers'
+            $ref: '#/components/schemas/AuthorizationServers'
 
-    AuthorisationServer:
-      description: Authorisation server response
+    AuthorizationServer:
+      description: Authorization server response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServer'
+            $ref: '#/components/schemas/AuthorizationServer'
 
     CertificatesOrKeys:
       description: All certificates for the org
@@ -695,61 +695,61 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUser'
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       description: All users belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUsers'
+            $ref: '#/components/schemas/AuthorizationDomainUsers'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       description: User data belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUser'
+            $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       description: All data of authorisation domains mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomains'
+            $ref: '#/components/schemas/AuthorizationDomains'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       description: Data of an authorisation domain mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomain'
+            $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       description: All roles data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoles'
+            $ref: '#/components/schemas/AuthorizationDomainRoles'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       description: Role data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRole'
+            $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       description: All authority to domain mappings data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomains'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomains'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       description: Authority to domain mapping data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
     OrganisationAuthorityDomainClaims:
       description: All authority to domain mappings data
@@ -815,28 +815,28 @@ components:
             $ref: '#/components/schemas/OrganisationAdminUser'
 
     ApiResources:
-      description: Authorisation server Api Resources response
+      description: Authorization server Api Resources response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResources'
 
     ApiResource:
-      description: Authorisation server Api Resource response
+      description: Authorization server Api Resource response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResource'
 
     ApiDiscoveryEndpoints:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiDiscoveryEndpoints'
 
     ApiDiscoveryEndpoint:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
@@ -923,15 +923,15 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation Domain for the authority
+          description: Authorization Domain for the authority
           maxLength: 30
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
           maxLength: 30
-        Authorisations:
+        Authorizations:
           type: array
           items:
             type: object
@@ -970,12 +970,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Role for the authority
@@ -996,20 +996,20 @@ components:
       required:
         - RegistrationId
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - AuthorityId
         - Role
 
-    OrganisationAuthorityClaimAuthorisations:
+    OrganisationAuthorityClaimAuthorizations:
       type: array
       items:
-        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    OrganisationAuthorityClaimAuthorisation:
+    OrganisationAuthorityClaimAuthorization:
       type: object
       properties:
-        OrganisationAuthorisationId:
-          $ref: '#/components/schemas/OrganisationAuthorisationId'
+        OrganisationAuthorizationId:
+          $ref: '#/components/schemas/OrganisationAuthorizationId'
         OrganisationAuthorityClaimId:
           $ref: '#/components/schemas/OrganisationAuthorityClaimId'
         Status:
@@ -1024,7 +1024,7 @@ components:
           description: Abbreviated states information i.e. GB, IE, NL etc
           maxLength: 10
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       type: object
       properties:
         Status:
@@ -1045,16 +1045,16 @@ components:
         - Status
         - MemberState
 
-    AuthorisationServers:
+    AuthorizationServers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationServer'
+        $ref: '#/components/schemas/AuthorizationServer'
 
-    AuthorisationServer:
+    AuthorizationServer:
       type: object
       properties:
-        AuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        AuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
         OrganisationId:
           $ref: '#/components/schemas/OrganisationId'
         AutoRegistrationSupported:
@@ -1114,10 +1114,10 @@ components:
           type: string
           format: uri
           maxLength: 256
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       type: object
       properties:
         AutoRegistrationSupported:
@@ -1174,8 +1174,8 @@ components:
           type: string
           maxLength: 256
           x-required-message: PayloadSigningCertLocationUri must be provided
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
       required:
         - AutoRegistrationSupported
         - CustomerFriendlyName
@@ -1185,7 +1185,7 @@ components:
         - OpenIDDiscoveryDocument
         - PayloadSigningCertLocationUri
 
-    AuthorisationServerId:
+    AuthorizationServerId:
       type: string
       maxLength: 40
     CertificateOrKeyOrJWT:
@@ -1790,7 +1790,7 @@ components:
       minLength: 1
       maxLength: 40
 
-    OrganisationAuthorisationId:
+    OrganisationAuthorizationId:
       type: string
       description: Unique ID associated with authorisations for organisation's authority claims
       minLength: 1
@@ -1804,7 +1804,7 @@ components:
 
     AuthorityId:
       type: string
-      description: Unique ID associated with the Authorisation reference schema
+      description: Unique ID associated with the Authorization reference schema
       minLength: 1
       maxLength: 40
 
@@ -2014,8 +2014,8 @@ components:
           $ref: '#/components/schemas/Organisation'
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2106,8 +2106,8 @@ components:
           maxLength: 65535
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2389,9 +2389,9 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           maxLength: 30
         Role:
           type: string
@@ -2408,12 +2408,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
@@ -2422,7 +2422,7 @@ components:
           x-required-message: Role must be provided
       required:
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - Role
 
     SoftwareAuthorityClaimUpdateRequest:
@@ -2644,22 +2644,22 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainName:
+    AuthorizationDomainName:
       type: string
-      description: Authorisation Domain Name
+      description: Authorization Domain Name
       maxLength: 30
 
-    AuthorisationDomainRoleName:
+    AuthorizationDomainRoleName:
       type: string
-      description: Authorisation Domain Role Name
+      description: Authorization Domain Role Name
       maxLength: 30
 
-    AuthorityAuthorisationDomainId:
+    AuthorityAuthorizationDomainId:
       type: string
-      description: Mapping ID between Authority and Authorisation Domain
+      description: Mapping ID between Authority and Authorization Domain
       maxLength: 50
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       type: object
       properties:
         Email:
@@ -2667,7 +2667,7 @@ components:
           description: The user email address
           pattern: "^(.{1,}@[^.]{1,}).*"
           x-pattern-message: "EmailAddress must be a valid email"
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
           minLength: 1
@@ -2675,27 +2675,27 @@ components:
           $ref: '#/components/schemas/ContactRoleEnum'
       required:
         - Email
-        - AuthorisationDomainRole
+        - AuthorizationDomainRole
         - ContactRole
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainUser'
+        $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       type: object
       properties:
-        AuthorisationDomainUserId:
+        AuthorizationDomainUserId:
           type: string
           description: Unique record ID
         Email:
           type: string
           description: The user email address
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
           description: The authorisation domain for this user
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
         Status:
@@ -2714,42 +2714,42 @@ components:
             - PBC
             - SBC
 
-    AuthorisationDomainRequest:
+    AuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
           minLength: 2
           x-required-message: The authorisation domain region is mandatory
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
       required:
-        - AuthorisationDomainName
-        - AuthorisationDomainRegion
+        - AuthorizationDomainName
+        - AuthorizationDomainRegion
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomain'
+        $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
         Status:
@@ -2760,42 +2760,42 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainRoleRequest:
+    AuthorizationDomainRoleRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain role name is mandatory
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
       required:
-        - AuthorisationDomainRoleName
-        - AuthorisationDomainName
+        - AuthorizationDomainRoleName
+        - AuthorizationDomainName
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainRole'
+        $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
         Status:
@@ -2806,32 +2806,32 @@ components:
             - Inactive
           default: Active
 
-    AuthorityAuthorisationDomainRequest:
+    AuthorityAuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
       required:
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
           type: string
           description: The GUID of the Authority
-        AuthorityAuthorisationDomainId:
+        AuthorityAuthorizationDomainId:
           type: string
           description: The GUID of the Authority-Domain mapping
         Status:
@@ -2850,7 +2850,7 @@ components:
     OrganisationAuthorityDomainClaimRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
@@ -2865,7 +2865,7 @@ components:
           description: The registration ID
       required:
         - AuthorityId
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
     OrganisationAuthorityDomainClaims:
       type: array
@@ -2878,7 +2878,7 @@ components:
         OrganisationAuthorityDomainClaimId:
           type: string
           description: The unique org authority domain claim ID
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
@@ -2898,7 +2898,7 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainUserId:
+    AuthorizationDomainUserId:
       type: string
       description: Unique record ID to identify Domain user
       maxLength: 50
@@ -3152,9 +3152,9 @@ components:
     DomainRoleDetail:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
         Status:
           $ref: '#/components/schemas/StatusEnum'
@@ -3539,7 +3539,7 @@ components:
       type: string
       description: The envelope id of the ess signing request
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       type: object
       properties:
         Status:

--- a/documentation/source/versions/v1.0.0-rc6.0/swagger/swagger_resources_apis.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.0/swagger/swagger_resources_apis.yaml
@@ -121,7 +121,7 @@ components:
                   Available - Disponível
                   Unavailable - Indisponível
                   Temporary Unavailable - Temporariamente Indisponível
-                  Pending Authorisation - Pendente de Autorização
+                  Pending Authorization - Pendente de Autorização
                 example: AVAILABLE
             additionalProperties: false
           minItems: 1

--- a/documentation/source/versions/v1.0.0-rc6.1/index.html
+++ b/documentation/source/versions/v1.0.0-rc6.1/index.html
@@ -37867,7 +37867,7 @@ This operation does not require authentication
 <td>» status</td>
 <td>string</td>
 <td>true</td>
-<td>Tipo de status de recurso (vide Enum):<br>Available - Disponível<br>Unavailable - Indisponível<br>Temporary Unavailable - Temporariamente Indisponível<br>Pending Authorisation - Pendente de Autorização</td>
+<td>Tipo de status de recurso (vide Enum):<br>Available - Disponível<br>Unavailable - Indisponível<br>Temporary Unavailable - Temporariamente Indisponível<br>Pending Authorization - Pendente de Autorização</td>
 </tr>
 <tr>
 <td>links</td>
@@ -52700,7 +52700,7 @@ Espera-se que o detentor dos dados garanta que a medição do tempo de resposta 
 <td style="text-align: left">O Identificador do participante</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.CustomerFriendlyName</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.CustomerFriendlyName</strong></td>
 <td style="text-align: left">Nome da marca</td>
 </tr>
 <tr>
@@ -52720,19 +52720,19 @@ Espera-se que o detentor dos dados garanta que a medição do tempo de resposta 
 <td style="text-align: left">Status do papel</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIFamilyTipe</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIFamilyTipe</strong></td>
 <td style="text-align: left">URL das APIs</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIVersion</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIVersion</strong></td>
 <td style="text-align: left"></td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIEndPoint</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIEndPoint</strong></td>
 <td style="text-align: left"></td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.DeveloperPortalURI</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.DeveloperPortalURI</strong></td>
 <td style="text-align: left">URL da documentação sobre a API do participante</td>
 </tr>
 </tbody></table>

--- a/documentation/source/versions/v1.0.0-rc6.1/swagger/parts/schemas/enum/EnumResourceStatusType.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.1/swagger/parts/schemas/enum/EnumResourceStatusType.yaml
@@ -9,5 +9,5 @@ description: |
   Available - Disponível
   Unavailable - Indisponível
   Temporary Unavailable - Temporariamente Indisponível
-  Pending Authorisation - Pendente de Autorização
+  Pending Authorization - Pendente de Autorização
 example: 'AVAILABLE'

--- a/documentation/source/versions/v1.0.0-rc6.1/swagger/swagger_open_banking_apis.yml
+++ b/documentation/source/versions/v1.0.0-rc6.1/swagger/swagger_open_banking_apis.yml
@@ -3228,7 +3228,7 @@ components:
                   Available - Disponível
                   Unavailable - Indisponível
                   Temporary Unavailable - Temporariamente Indisponível
-                  Pending Authorisation - Pendente de Autorização
+                  Pending Authorization - Pendente de Autorização
                 example: AVAILABLE
             additionalProperties: false
           minItems: 1

--- a/documentation/source/versions/v1.0.0-rc6.1/swagger/swagger_participants.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.1/swagger/swagger_participants.yaml
@@ -37,13 +37,13 @@ components:
       in: query
       schema:
         $ref: '#/components/schemas/PageableRequest'
-    AuthorisationServerId:
-      name: AuthorisationServerId
+    AuthorizationServerId:
+      name: AuthorizationServerId
       description: The authorisation server Id
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationServerId'
+        $ref: '#/components/schemas/AuthorizationServerId'
     OrganisationAuthorityClaimId:
       name: OrganisationAuthorityClaimId
       description: The Authority claims ID for an organisation
@@ -51,13 +51,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityClaimId'
-    OrganisationAuthorisationId:
-      name: OrganisationAuthorisationId
+    OrganisationAuthorizationId:
+      name: OrganisationAuthorizationId
       description: The authorisation ID for an organisation's authority claims
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/OrganisationAuthorisationId'
+        $ref: '#/components/schemas/OrganisationAuthorizationId'
     CertificateOrKeyId:
       name: CertificateOrKeyId
       description: The certificate or key Id
@@ -121,27 +121,27 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/UserEmailId'
-    AuthorisationDomainName:
-      name: AuthorisationDomainName
-      description: Authorisation Domain Name. Eg:PSD2
+    AuthorizationDomainName:
+      name: AuthorizationDomainName
+      description: Authorization Domain Name. Eg:PSD2
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainName'
-    AuthorisationDomainRoleName:
-      name: AuthorisationDomainRoleName
-      description: Authorisation Domain Role Name. Eg:TPP
+        $ref: '#/components/schemas/AuthorizationDomainName'
+    AuthorizationDomainRoleName:
+      name: AuthorizationDomainRoleName
+      description: Authorization Domain Role Name. Eg:TPP
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainRoleName'
-    AuthorityAuthorisationDomainId:
-      name: AuthorityAuthorisationDomainId
-      description: ID of the Authority mapped with Authorisation Domain
+        $ref: '#/components/schemas/AuthorizationDomainRoleName'
+    AuthorityAuthorizationDomainId:
+      name: AuthorityAuthorizationDomainId
+      description: ID of the Authority mapped with Authorization Domain
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomainId'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomainId'
     OrganisationAuthorityDomainClaimId:
       name: OrganisationAuthorityDomainClaimId
       description: Organisation Authority Domain Claim Id
@@ -149,13 +149,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityDomainClaimId'
-    AuthorisationDomainUserId:
-      name: AuthorisationDomainUserId
+    AuthorizationDomainUserId:
+      name: AuthorizationDomainUserId
       description: Unique record Id to identify Domain User
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainUserId'
+        $ref: '#/components/schemas/AuthorizationDomainUserId'
     TnCId:
       name: TnCId
       description: Terms and Conditions unique identifier
@@ -202,13 +202,13 @@ components:
           schema:
             $ref: '#/components/schemas/AmendCertificateRequest'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       description: Properties to create/update authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServerRequest'
+            $ref: '#/components/schemas/AuthorizationServerRequest'
 
     OrganisationAuthorityClaimRequest:
       description: Properties to create/update authority claims
@@ -227,13 +227,13 @@ components:
             $ref: '#/components/schemas/UserUpdateRequest'
 
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       description: Properties to update/retrieve authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisationRequest'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizationRequest'
     ContactRequest:
       description: Properties to update contacts
       required: true
@@ -375,40 +375,40 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUserCreationRequest'
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       description: Admin user creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserCreateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserCreateRequest'
 
-    AuthorisationDomainRequest:
-      description: Authorisation Domain creation request
+    AuthorizationDomainRequest:
+      description: Authorization Domain creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRequest'
 
-    AuthorisationDomainRoleRequest:
-      description: Authorisation Domain Role creation request
+    AuthorizationDomainRoleRequest:
+      description: Authorization Domain Role creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoleRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRoleRequest'
 
-    AuthorityAuthorisationDomainRequest:
-      description: Authority Authorisation Domain mapping request
+    AuthorityAuthorizationDomainRequest:
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomainRequest'
 
     OrganisationAuthorityDomainClaimRequest:
-      description: Authority Authorisation Domain mapping request
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
@@ -467,12 +467,12 @@ components:
           schema:
             $ref: '#/components/schemas/EssSignRequest'
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       description: Request object to update a domain user
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserUpdateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserUpdateRequest'
 
   responses:
     NoContent:
@@ -510,33 +510,33 @@ components:
           schema:
             $ref: '#/components/schemas/OrganisationAuthorityClaim'
 
-    OrganisationAuthorityClaimAuthorisations:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorizations:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisations'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizations'
 
-    OrganisationAuthorityClaimAuthorisation:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorization:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    AuthorisationServers:
+    AuthorizationServers:
       description: All authorisation servers for the org
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServers'
+            $ref: '#/components/schemas/AuthorizationServers'
 
-    AuthorisationServer:
-      description: Authorisation server response
+    AuthorizationServer:
+      description: Authorization server response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServer'
+            $ref: '#/components/schemas/AuthorizationServer'
 
     CertificatesOrKeys:
       description: All certificates for the org
@@ -695,61 +695,61 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUser'
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       description: All users belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUsers'
+            $ref: '#/components/schemas/AuthorizationDomainUsers'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       description: User data belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUser'
+            $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       description: All data of authorisation domains mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomains'
+            $ref: '#/components/schemas/AuthorizationDomains'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       description: Data of an authorisation domain mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomain'
+            $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       description: All roles data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoles'
+            $ref: '#/components/schemas/AuthorizationDomainRoles'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       description: Role data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRole'
+            $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       description: All authority to domain mappings data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomains'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomains'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       description: Authority to domain mapping data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
     OrganisationAuthorityDomainClaims:
       description: All authority to domain mappings data
@@ -815,28 +815,28 @@ components:
             $ref: '#/components/schemas/OrganisationAdminUser'
 
     ApiResources:
-      description: Authorisation server Api Resources response
+      description: Authorization server Api Resources response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResources'
 
     ApiResource:
-      description: Authorisation server Api Resource response
+      description: Authorization server Api Resource response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResource'
 
     ApiDiscoveryEndpoints:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiDiscoveryEndpoints'
 
     ApiDiscoveryEndpoint:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
@@ -923,15 +923,15 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation Domain for the authority
+          description: Authorization Domain for the authority
           maxLength: 30
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
           maxLength: 30
-        Authorisations:
+        Authorizations:
           type: array
           items:
             type: object
@@ -970,12 +970,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Role for the authority
@@ -996,20 +996,20 @@ components:
       required:
         - RegistrationId
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - AuthorityId
         - Role
 
-    OrganisationAuthorityClaimAuthorisations:
+    OrganisationAuthorityClaimAuthorizations:
       type: array
       items:
-        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    OrganisationAuthorityClaimAuthorisation:
+    OrganisationAuthorityClaimAuthorization:
       type: object
       properties:
-        OrganisationAuthorisationId:
-          $ref: '#/components/schemas/OrganisationAuthorisationId'
+        OrganisationAuthorizationId:
+          $ref: '#/components/schemas/OrganisationAuthorizationId'
         OrganisationAuthorityClaimId:
           $ref: '#/components/schemas/OrganisationAuthorityClaimId'
         Status:
@@ -1024,7 +1024,7 @@ components:
           description: Abbreviated states information i.e. GB, IE, NL etc
           maxLength: 10
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       type: object
       properties:
         Status:
@@ -1045,16 +1045,16 @@ components:
         - Status
         - MemberState
 
-    AuthorisationServers:
+    AuthorizationServers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationServer'
+        $ref: '#/components/schemas/AuthorizationServer'
 
-    AuthorisationServer:
+    AuthorizationServer:
       type: object
       properties:
-        AuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        AuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
         OrganisationId:
           $ref: '#/components/schemas/OrganisationId'
         AutoRegistrationSupported:
@@ -1114,10 +1114,10 @@ components:
           type: string
           format: uri
           maxLength: 256
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       type: object
       properties:
         AutoRegistrationSupported:
@@ -1174,8 +1174,8 @@ components:
           type: string
           maxLength: 256
           x-required-message: PayloadSigningCertLocationUri must be provided
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
       required:
         - AutoRegistrationSupported
         - CustomerFriendlyName
@@ -1185,7 +1185,7 @@ components:
         - OpenIDDiscoveryDocument
         - PayloadSigningCertLocationUri
 
-    AuthorisationServerId:
+    AuthorizationServerId:
       type: string
       maxLength: 40
     CertificateOrKeyOrJWT:
@@ -1790,7 +1790,7 @@ components:
       minLength: 1
       maxLength: 40
 
-    OrganisationAuthorisationId:
+    OrganisationAuthorizationId:
       type: string
       description: Unique ID associated with authorisations for organisation's authority claims
       minLength: 1
@@ -1804,7 +1804,7 @@ components:
 
     AuthorityId:
       type: string
-      description: Unique ID associated with the Authorisation reference schema
+      description: Unique ID associated with the Authorization reference schema
       minLength: 1
       maxLength: 40
 
@@ -2014,8 +2014,8 @@ components:
           $ref: '#/components/schemas/Organisation'
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2106,8 +2106,8 @@ components:
           maxLength: 65535
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2389,9 +2389,9 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           maxLength: 30
         Role:
           type: string
@@ -2408,12 +2408,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
@@ -2422,7 +2422,7 @@ components:
           x-required-message: Role must be provided
       required:
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - Role
 
     SoftwareAuthorityClaimUpdateRequest:
@@ -2644,22 +2644,22 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainName:
+    AuthorizationDomainName:
       type: string
-      description: Authorisation Domain Name
+      description: Authorization Domain Name
       maxLength: 30
 
-    AuthorisationDomainRoleName:
+    AuthorizationDomainRoleName:
       type: string
-      description: Authorisation Domain Role Name
+      description: Authorization Domain Role Name
       maxLength: 30
 
-    AuthorityAuthorisationDomainId:
+    AuthorityAuthorizationDomainId:
       type: string
-      description: Mapping ID between Authority and Authorisation Domain
+      description: Mapping ID between Authority and Authorization Domain
       maxLength: 50
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       type: object
       properties:
         Email:
@@ -2667,7 +2667,7 @@ components:
           description: The user email address
           pattern: "^(.{1,}@[^.]{1,}).*"
           x-pattern-message: "EmailAddress must be a valid email"
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
           minLength: 1
@@ -2675,27 +2675,27 @@ components:
           $ref: '#/components/schemas/ContactRoleEnum'
       required:
         - Email
-        - AuthorisationDomainRole
+        - AuthorizationDomainRole
         - ContactRole
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainUser'
+        $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       type: object
       properties:
-        AuthorisationDomainUserId:
+        AuthorizationDomainUserId:
           type: string
           description: Unique record ID
         Email:
           type: string
           description: The user email address
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
           description: The authorisation domain for this user
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
         Status:
@@ -2714,42 +2714,42 @@ components:
             - PBC
             - SBC
 
-    AuthorisationDomainRequest:
+    AuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
           minLength: 2
           x-required-message: The authorisation domain region is mandatory
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
       required:
-        - AuthorisationDomainName
-        - AuthorisationDomainRegion
+        - AuthorizationDomainName
+        - AuthorizationDomainRegion
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomain'
+        $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
         Status:
@@ -2760,42 +2760,42 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainRoleRequest:
+    AuthorizationDomainRoleRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain role name is mandatory
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
       required:
-        - AuthorisationDomainRoleName
-        - AuthorisationDomainName
+        - AuthorizationDomainRoleName
+        - AuthorizationDomainName
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainRole'
+        $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
         Status:
@@ -2806,32 +2806,32 @@ components:
             - Inactive
           default: Active
 
-    AuthorityAuthorisationDomainRequest:
+    AuthorityAuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
       required:
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
           type: string
           description: The GUID of the Authority
-        AuthorityAuthorisationDomainId:
+        AuthorityAuthorizationDomainId:
           type: string
           description: The GUID of the Authority-Domain mapping
         Status:
@@ -2850,7 +2850,7 @@ components:
     OrganisationAuthorityDomainClaimRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
@@ -2865,7 +2865,7 @@ components:
           description: The registration ID
       required:
         - AuthorityId
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
     OrganisationAuthorityDomainClaims:
       type: array
@@ -2878,7 +2878,7 @@ components:
         OrganisationAuthorityDomainClaimId:
           type: string
           description: The unique org authority domain claim ID
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
@@ -2898,7 +2898,7 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainUserId:
+    AuthorizationDomainUserId:
       type: string
       description: Unique record ID to identify Domain user
       maxLength: 50
@@ -3152,9 +3152,9 @@ components:
     DomainRoleDetail:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
         Status:
           $ref: '#/components/schemas/StatusEnum'
@@ -3539,7 +3539,7 @@ components:
       type: string
       description: The envelope id of the ess signing request
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       type: object
       properties:
         Status:

--- a/documentation/source/versions/v1.0.0-rc6.1/swagger/swagger_resources_apis.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.1/swagger/swagger_resources_apis.yaml
@@ -121,7 +121,7 @@ components:
                   Available - Disponível
                   Unavailable - Indisponível
                   Temporary Unavailable - Temporariamente Indisponível
-                  Pending Authorisation - Pendente de Autorização
+                  Pending Authorization - Pendente de Autorização
                 example: AVAILABLE
             additionalProperties: false
           minItems: 1

--- a/documentation/source/versions/v1.0.0-rc6.2/index.html
+++ b/documentation/source/versions/v1.0.0-rc6.2/index.html
@@ -3961,7 +3961,7 @@ acesso e servidores de autorização no ambiente de sandbox e produção do Dire
 <li>Introdução</li>
 <li>Registrando um usuário no Diretório</li>
 <li>Acessando uma Organisation</li>
-<li>Cadastrando um Authorisation Server</li>
+<li>Cadastrando um Authorization Server</li>
 <li>Cadastrando Recursos de uma API</li>
 <li>Criando um Software Statements</li>
 <li>Criando uma solicitação de Assinatura de Certificado (CSR) em Sandbox</li>
@@ -3994,16 +3994,16 @@ directory/blob/main/openapi.yaml">https://github.com/OpenBanking-Brasil/specs-di
 <ul>
 <li>Organisations</li>
 <li>References - Authority</li>
-<li>References - Authorisation Domain</li>
-<li>References - Authorisation Domain Role</li>
-<li>References - Authority Authorisation Domain</li>
+<li>References - Authorization Domain</li>
+<li>References - Authorization Domain Role</li>
+<li>References - Authority Authorization Domain</li>
 <li>Organisation Authority Domain Claims</li>
 <li>Organisation Authority Claims</li>
-<li>Organisation Authority Claims Authorisations</li>
+<li>Organisation Authority Claims Authorizations</li>
 <li>Contacts</li>
-<li>Authorisation Servers</li>
-<li>Authorisation Servers - API Resources</li>
-<li>Authorisation Servers - API Discovery Endpoints</li>
+<li>Authorization Servers</li>
+<li>Authorization Servers - API Resources</li>
+<li>Authorization Servers - API Discovery Endpoints</li>
 <li>Software Statements</li>
 <li>Software Statement Authority Claims</li>
 <li>Software Statement Certificates</li>
@@ -16494,7 +16494,7 @@ This operation does not require authentication
 <td>» status</td>
 <td>string</td>
 <td>true</td>
-<td>Tipo de status de recurso (vide Enum):<br>Available - Disponível<br>Unavailable - Indisponível<br>Temporary Unavailable - Temporariamente Indisponível<br>Pending Authorisation - Pendente de Autorização</td>
+<td>Tipo de status de recurso (vide Enum):<br>Available - Disponível<br>Unavailable - Indisponível<br>Temporary Unavailable - Temporariamente Indisponível<br>Pending Authorization - Pendente de Autorização</td>
 </tr>
 <tr>
 <td>links</td>
@@ -31800,7 +31800,7 @@ Espera-se que o detentor dos dados garanta que a medição do tempo de resposta 
 <td style="text-align: left">O Identificador do participante</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.CustomerFriendlyName</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.CustomerFriendlyName</strong></td>
 <td style="text-align: left">Nome da marca</td>
 </tr>
 <tr>
@@ -31820,19 +31820,19 @@ Espera-se que o detentor dos dados garanta que a medição do tempo de resposta 
 <td style="text-align: left">Status do papel</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIFamilyTipe</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIFamilyTipe</strong></td>
 <td style="text-align: left">URL das APIs</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIVersion</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIVersion</strong></td>
 <td style="text-align: left"></td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIEndPoint</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIEndPoint</strong></td>
 <td style="text-align: left"></td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.DeveloperPortalURI</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.DeveloperPortalURI</strong></td>
 <td style="text-align: left">URL da documentação sobre a API do participante</td>
 </tr>
 </tbody></table>

--- a/documentation/source/versions/v1.0.0-rc6.2/swagger/parts/schemas/enum/EnumResourceStatusType.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.2/swagger/parts/schemas/enum/EnumResourceStatusType.yaml
@@ -9,5 +9,5 @@ description: |
   Available - Disponível
   Unavailable - Indisponível
   Temporary Unavailable - Temporariamente Indisponível
-  Pending Authorisation - Pendente de Autorização
+  Pending Authorization - Pendente de Autorização
 example: 'AVAILABLE'

--- a/documentation/source/versions/v1.0.0-rc6.2/swagger/swagger_open_banking_apis.yml
+++ b/documentation/source/versions/v1.0.0-rc6.2/swagger/swagger_open_banking_apis.yml
@@ -3228,7 +3228,7 @@ components:
                   Available - Disponível
                   Unavailable - Indisponível
                   Temporary Unavailable - Temporariamente Indisponível
-                  Pending Authorisation - Pendente de Autorização
+                  Pending Authorization - Pendente de Autorização
                 example: AVAILABLE
             additionalProperties: false
           minItems: 1

--- a/documentation/source/versions/v1.0.0-rc6.2/swagger/swagger_participants.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.2/swagger/swagger_participants.yaml
@@ -37,13 +37,13 @@ components:
       in: query
       schema:
         $ref: '#/components/schemas/PageableRequest'
-    AuthorisationServerId:
-      name: AuthorisationServerId
+    AuthorizationServerId:
+      name: AuthorizationServerId
       description: The authorisation server Id
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationServerId'
+        $ref: '#/components/schemas/AuthorizationServerId'
     OrganisationAuthorityClaimId:
       name: OrganisationAuthorityClaimId
       description: The Authority claims ID for an organisation
@@ -51,13 +51,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityClaimId'
-    OrganisationAuthorisationId:
-      name: OrganisationAuthorisationId
+    OrganisationAuthorizationId:
+      name: OrganisationAuthorizationId
       description: The authorisation ID for an organisation's authority claims
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/OrganisationAuthorisationId'
+        $ref: '#/components/schemas/OrganisationAuthorizationId'
     CertificateOrKeyId:
       name: CertificateOrKeyId
       description: The certificate or key Id
@@ -121,27 +121,27 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/UserEmailId'
-    AuthorisationDomainName:
-      name: AuthorisationDomainName
-      description: Authorisation Domain Name. Eg:PSD2
+    AuthorizationDomainName:
+      name: AuthorizationDomainName
+      description: Authorization Domain Name. Eg:PSD2
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainName'
-    AuthorisationDomainRoleName:
-      name: AuthorisationDomainRoleName
-      description: Authorisation Domain Role Name. Eg:TPP
+        $ref: '#/components/schemas/AuthorizationDomainName'
+    AuthorizationDomainRoleName:
+      name: AuthorizationDomainRoleName
+      description: Authorization Domain Role Name. Eg:TPP
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainRoleName'
-    AuthorityAuthorisationDomainId:
-      name: AuthorityAuthorisationDomainId
-      description: ID of the Authority mapped with Authorisation Domain
+        $ref: '#/components/schemas/AuthorizationDomainRoleName'
+    AuthorityAuthorizationDomainId:
+      name: AuthorityAuthorizationDomainId
+      description: ID of the Authority mapped with Authorization Domain
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomainId'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomainId'
     OrganisationAuthorityDomainClaimId:
       name: OrganisationAuthorityDomainClaimId
       description: Organisation Authority Domain Claim Id
@@ -149,13 +149,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityDomainClaimId'
-    AuthorisationDomainUserId:
-      name: AuthorisationDomainUserId
+    AuthorizationDomainUserId:
+      name: AuthorizationDomainUserId
       description: Unique record Id to identify Domain User
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainUserId'
+        $ref: '#/components/schemas/AuthorizationDomainUserId'
     TnCId:
       name: TnCId
       description: Terms and Conditions unique identifier
@@ -202,13 +202,13 @@ components:
           schema:
             $ref: '#/components/schemas/AmendCertificateRequest'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       description: Properties to create/update authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServerRequest'
+            $ref: '#/components/schemas/AuthorizationServerRequest'
 
     OrganisationAuthorityClaimRequest:
       description: Properties to create/update authority claims
@@ -227,13 +227,13 @@ components:
             $ref: '#/components/schemas/UserUpdateRequest'
 
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       description: Properties to update/retrieve authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisationRequest'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizationRequest'
     ContactRequest:
       description: Properties to update contacts
       required: true
@@ -375,40 +375,40 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUserCreationRequest'
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       description: Admin user creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserCreateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserCreateRequest'
 
-    AuthorisationDomainRequest:
-      description: Authorisation Domain creation request
+    AuthorizationDomainRequest:
+      description: Authorization Domain creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRequest'
 
-    AuthorisationDomainRoleRequest:
-      description: Authorisation Domain Role creation request
+    AuthorizationDomainRoleRequest:
+      description: Authorization Domain Role creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoleRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRoleRequest'
 
-    AuthorityAuthorisationDomainRequest:
-      description: Authority Authorisation Domain mapping request
+    AuthorityAuthorizationDomainRequest:
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomainRequest'
 
     OrganisationAuthorityDomainClaimRequest:
-      description: Authority Authorisation Domain mapping request
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
@@ -467,12 +467,12 @@ components:
           schema:
             $ref: '#/components/schemas/EssSignRequest'
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       description: Request object to update a domain user
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserUpdateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserUpdateRequest'
 
   responses:
     NoContent:
@@ -510,33 +510,33 @@ components:
           schema:
             $ref: '#/components/schemas/OrganisationAuthorityClaim'
 
-    OrganisationAuthorityClaimAuthorisations:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorizations:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisations'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizations'
 
-    OrganisationAuthorityClaimAuthorisation:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorization:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    AuthorisationServers:
+    AuthorizationServers:
       description: All authorisation servers for the org
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServers'
+            $ref: '#/components/schemas/AuthorizationServers'
 
-    AuthorisationServer:
-      description: Authorisation server response
+    AuthorizationServer:
+      description: Authorization server response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServer'
+            $ref: '#/components/schemas/AuthorizationServer'
 
     CertificatesOrKeys:
       description: All certificates for the org
@@ -695,61 +695,61 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUser'
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       description: All users belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUsers'
+            $ref: '#/components/schemas/AuthorizationDomainUsers'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       description: User data belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUser'
+            $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       description: All data of authorisation domains mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomains'
+            $ref: '#/components/schemas/AuthorizationDomains'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       description: Data of an authorisation domain mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomain'
+            $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       description: All roles data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoles'
+            $ref: '#/components/schemas/AuthorizationDomainRoles'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       description: Role data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRole'
+            $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       description: All authority to domain mappings data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomains'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomains'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       description: Authority to domain mapping data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
     OrganisationAuthorityDomainClaims:
       description: All authority to domain mappings data
@@ -815,28 +815,28 @@ components:
             $ref: '#/components/schemas/OrganisationAdminUser'
 
     ApiResources:
-      description: Authorisation server Api Resources response
+      description: Authorization server Api Resources response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResources'
 
     ApiResource:
-      description: Authorisation server Api Resource response
+      description: Authorization server Api Resource response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResource'
 
     ApiDiscoveryEndpoints:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiDiscoveryEndpoints'
 
     ApiDiscoveryEndpoint:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
@@ -923,15 +923,15 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation Domain for the authority
+          description: Authorization Domain for the authority
           maxLength: 30
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
           maxLength: 30
-        Authorisations:
+        Authorizations:
           type: array
           items:
             type: object
@@ -970,12 +970,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Role for the authority
@@ -996,20 +996,20 @@ components:
       required:
         - RegistrationId
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - AuthorityId
         - Role
 
-    OrganisationAuthorityClaimAuthorisations:
+    OrganisationAuthorityClaimAuthorizations:
       type: array
       items:
-        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    OrganisationAuthorityClaimAuthorisation:
+    OrganisationAuthorityClaimAuthorization:
       type: object
       properties:
-        OrganisationAuthorisationId:
-          $ref: '#/components/schemas/OrganisationAuthorisationId'
+        OrganisationAuthorizationId:
+          $ref: '#/components/schemas/OrganisationAuthorizationId'
         OrganisationAuthorityClaimId:
           $ref: '#/components/schemas/OrganisationAuthorityClaimId'
         Status:
@@ -1024,7 +1024,7 @@ components:
           description: Abbreviated states information i.e. GB, IE, NL etc
           maxLength: 10
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       type: object
       properties:
         Status:
@@ -1045,16 +1045,16 @@ components:
         - Status
         - MemberState
 
-    AuthorisationServers:
+    AuthorizationServers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationServer'
+        $ref: '#/components/schemas/AuthorizationServer'
 
-    AuthorisationServer:
+    AuthorizationServer:
       type: object
       properties:
-        AuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        AuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
         OrganisationId:
           $ref: '#/components/schemas/OrganisationId'
         AutoRegistrationSupported:
@@ -1114,10 +1114,10 @@ components:
           type: string
           format: uri
           maxLength: 256
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       type: object
       properties:
         AutoRegistrationSupported:
@@ -1174,8 +1174,8 @@ components:
           type: string
           maxLength: 256
           x-required-message: PayloadSigningCertLocationUri must be provided
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
       required:
         - AutoRegistrationSupported
         - CustomerFriendlyName
@@ -1185,7 +1185,7 @@ components:
         - OpenIDDiscoveryDocument
         - PayloadSigningCertLocationUri
 
-    AuthorisationServerId:
+    AuthorizationServerId:
       type: string
       maxLength: 40
     CertificateOrKeyOrJWT:
@@ -1790,7 +1790,7 @@ components:
       minLength: 1
       maxLength: 40
 
-    OrganisationAuthorisationId:
+    OrganisationAuthorizationId:
       type: string
       description: Unique ID associated with authorisations for organisation's authority claims
       minLength: 1
@@ -1804,7 +1804,7 @@ components:
 
     AuthorityId:
       type: string
-      description: Unique ID associated with the Authorisation reference schema
+      description: Unique ID associated with the Authorization reference schema
       minLength: 1
       maxLength: 40
 
@@ -2014,8 +2014,8 @@ components:
           $ref: '#/components/schemas/Organisation'
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2106,8 +2106,8 @@ components:
           maxLength: 65535
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2389,9 +2389,9 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           maxLength: 30
         Role:
           type: string
@@ -2408,12 +2408,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
@@ -2422,7 +2422,7 @@ components:
           x-required-message: Role must be provided
       required:
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - Role
 
     SoftwareAuthorityClaimUpdateRequest:
@@ -2644,22 +2644,22 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainName:
+    AuthorizationDomainName:
       type: string
-      description: Authorisation Domain Name
+      description: Authorization Domain Name
       maxLength: 30
 
-    AuthorisationDomainRoleName:
+    AuthorizationDomainRoleName:
       type: string
-      description: Authorisation Domain Role Name
+      description: Authorization Domain Role Name
       maxLength: 30
 
-    AuthorityAuthorisationDomainId:
+    AuthorityAuthorizationDomainId:
       type: string
-      description: Mapping ID between Authority and Authorisation Domain
+      description: Mapping ID between Authority and Authorization Domain
       maxLength: 50
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       type: object
       properties:
         Email:
@@ -2667,7 +2667,7 @@ components:
           description: The user email address
           pattern: "^(.{1,}@[^.]{1,}).*"
           x-pattern-message: "EmailAddress must be a valid email"
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
           minLength: 1
@@ -2675,27 +2675,27 @@ components:
           $ref: '#/components/schemas/ContactRoleEnum'
       required:
         - Email
-        - AuthorisationDomainRole
+        - AuthorizationDomainRole
         - ContactRole
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainUser'
+        $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       type: object
       properties:
-        AuthorisationDomainUserId:
+        AuthorizationDomainUserId:
           type: string
           description: Unique record ID
         Email:
           type: string
           description: The user email address
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
           description: The authorisation domain for this user
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
         Status:
@@ -2714,42 +2714,42 @@ components:
             - PBC
             - SBC
 
-    AuthorisationDomainRequest:
+    AuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
           minLength: 2
           x-required-message: The authorisation domain region is mandatory
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
       required:
-        - AuthorisationDomainName
-        - AuthorisationDomainRegion
+        - AuthorizationDomainName
+        - AuthorizationDomainRegion
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomain'
+        $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
         Status:
@@ -2760,42 +2760,42 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainRoleRequest:
+    AuthorizationDomainRoleRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain role name is mandatory
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
       required:
-        - AuthorisationDomainRoleName
-        - AuthorisationDomainName
+        - AuthorizationDomainRoleName
+        - AuthorizationDomainName
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainRole'
+        $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
         Status:
@@ -2806,32 +2806,32 @@ components:
             - Inactive
           default: Active
 
-    AuthorityAuthorisationDomainRequest:
+    AuthorityAuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
       required:
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
           type: string
           description: The GUID of the Authority
-        AuthorityAuthorisationDomainId:
+        AuthorityAuthorizationDomainId:
           type: string
           description: The GUID of the Authority-Domain mapping
         Status:
@@ -2850,7 +2850,7 @@ components:
     OrganisationAuthorityDomainClaimRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
@@ -2865,7 +2865,7 @@ components:
           description: The registration ID
       required:
         - AuthorityId
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
     OrganisationAuthorityDomainClaims:
       type: array
@@ -2878,7 +2878,7 @@ components:
         OrganisationAuthorityDomainClaimId:
           type: string
           description: The unique org authority domain claim ID
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
@@ -2898,7 +2898,7 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainUserId:
+    AuthorizationDomainUserId:
       type: string
       description: Unique record ID to identify Domain user
       maxLength: 50
@@ -3152,9 +3152,9 @@ components:
     DomainRoleDetail:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
         Status:
           $ref: '#/components/schemas/StatusEnum'
@@ -3539,7 +3539,7 @@ components:
       type: string
       description: The envelope id of the ess signing request
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       type: object
       properties:
         Status:

--- a/documentation/source/versions/v1.0.0-rc6.2/swagger/swagger_resources_apis.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.2/swagger/swagger_resources_apis.yaml
@@ -121,7 +121,7 @@ components:
                   Available - Disponível
                   Unavailable - Indisponível
                   Temporary Unavailable - Temporariamente Indisponível
-                  Pending Authorisation - Pendente de Autorização
+                  Pending Authorization - Pendente de Autorização
                 example: AVAILABLE
             additionalProperties: false
           minItems: 1

--- a/documentation/source/versions/v1.0.0-rc6.3/dictionary/resourcesGetResources_v1.csv
+++ b/documentation/source/versions/v1.0.0-rc6.3/dictionary/resourcesGetResources_v1.csv
@@ -20,7 +20,7 @@ INVOICE_FINANCING";1;1;"";Não permitido;string;ACCOUNT
 Available - Disponível
 Unavailable - Indisponível
 Temporarily Unavailable - Temporariamente Indisponível
-Pending Authorisation - Pendente de Autorização";Texto;;Obrigatório;;"AVAILABLE 
+Pending Authorization - Pendente de Autorização";Texto;;Obrigatório;;"AVAILABLE 
 UNAVAILABLE 
 TEMPORARILY_UNAVAILABLE 
 PENDING_AUTHORISATION";1;1;"";Não permitido;string;AVAILABLE

--- a/documentation/source/versions/v1.0.0-rc6.3/index.html
+++ b/documentation/source/versions/v1.0.0-rc6.3/index.html
@@ -4137,7 +4137,7 @@ acesso e servidores de autorização no ambiente de sandbox e produção do Dire
 <li>Introdução</li>
 <li>Registrando um usuário no Diretório</li>
 <li>Acessando uma Organisation</li>
-<li>Cadastrando um Authorisation Server</li>
+<li>Cadastrando um Authorization Server</li>
 <li>Cadastrando Recursos de uma API</li>
 <li>Criando um Software Statements</li>
 <li>Criando uma solicitação de Assinatura de Certificado (CSR) em Sandbox</li>
@@ -4170,16 +4170,16 @@ directory/blob/main/openapi.yaml">https://github.com/OpenBanking-Brasil/specs-di
 <ul>
 <li>Organisations</li>
 <li>References - Authority</li>
-<li>References - Authorisation Domain</li>
-<li>References - Authorisation Domain Role</li>
-<li>References - Authority Authorisation Domain</li>
+<li>References - Authorization Domain</li>
+<li>References - Authorization Domain Role</li>
+<li>References - Authority Authorization Domain</li>
 <li>Organisation Authority Domain Claims</li>
 <li>Organisation Authority Claims</li>
-<li>Organisation Authority Claims Authorisations</li>
+<li>Organisation Authority Claims Authorizations</li>
 <li>Contacts</li>
-<li>Authorisation Servers</li>
-<li>Authorisation Servers - API Resources</li>
-<li>Authorisation Servers - API Discovery Endpoints</li>
+<li>Authorization Servers</li>
+<li>Authorization Servers - API Resources</li>
+<li>Authorization Servers - API Discovery Endpoints</li>
 <li>Software Statements</li>
 <li>Software Statement Authority Claims</li>
 <li>Software Statement Certificates</li>
@@ -16649,7 +16649,7 @@ This operation does not require authentication
 <td>» status</td>
 <td>string</td>
 <td>true</td>
-<td>Tipo de status de recurso (vide Enum):<br>Available - Disponível<br>Unavailable - Indisponível<br>Temporarily Unavailable - Temporariamente Indisponível<br>Pending Authorisation - Pendente de Autorização</td>
+<td>Tipo de status de recurso (vide Enum):<br>Available - Disponível<br>Unavailable - Indisponível<br>Temporarily Unavailable - Temporariamente Indisponível<br>Pending Authorization - Pendente de Autorização</td>
 </tr>
 <tr>
 <td>links</td>
@@ -31955,7 +31955,7 @@ Espera-se que o detentor dos dados garanta que a medição do tempo de resposta 
 <td style="text-align: left">O Identificador do participante</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.CustomerFriendlyName</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.CustomerFriendlyName</strong></td>
 <td style="text-align: left">Nome da marca</td>
 </tr>
 <tr>
@@ -31975,19 +31975,19 @@ Espera-se que o detentor dos dados garanta que a medição do tempo de resposta 
 <td style="text-align: left">Status do papel</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIFamilyTipe</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIFamilyTipe</strong></td>
 <td style="text-align: left">URL das APIs</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIVersion</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIVersion</strong></td>
 <td style="text-align: left"></td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIEndPoint</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIEndPoint</strong></td>
 <td style="text-align: left"></td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.DeveloperPortalURI</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.DeveloperPortalURI</strong></td>
 <td style="text-align: left">URL da documentação sobre a API do participante</td>
 </tr>
 </tbody></table>

--- a/documentation/source/versions/v1.0.0-rc6.3/swagger/parts/schemas/enum/EnumResourceStatusType.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.3/swagger/parts/schemas/enum/EnumResourceStatusType.yaml
@@ -9,5 +9,5 @@ description: |
   Available - Disponível
   Unavailable - Indisponível
   Temporarily Unavailable - Temporariamente Indisponível
-  Pending Authorisation - Pendente de Autorização
+  Pending Authorization - Pendente de Autorização
 example: 'AVAILABLE'

--- a/documentation/source/versions/v1.0.0-rc6.3/swagger/swagger_open_banking_apis.yml
+++ b/documentation/source/versions/v1.0.0-rc6.3/swagger/swagger_open_banking_apis.yml
@@ -3227,7 +3227,7 @@ components:
                   Available - Disponível
                   Unavailable - Indisponível
                   Temporarily Unavailable - Temporariamente Indisponível
-                  Pending Authorisation - Pendente de Autorização
+                  Pending Authorization - Pendente de Autorização
                 example: AVAILABLE
             additionalProperties: false
           minItems: 1

--- a/documentation/source/versions/v1.0.0-rc6.3/swagger/swagger_participants.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.3/swagger/swagger_participants.yaml
@@ -37,13 +37,13 @@ components:
       in: query
       schema:
         $ref: '#/components/schemas/PageableRequest'
-    AuthorisationServerId:
-      name: AuthorisationServerId
+    AuthorizationServerId:
+      name: AuthorizationServerId
       description: The authorisation server Id
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationServerId'
+        $ref: '#/components/schemas/AuthorizationServerId'
     OrganisationAuthorityClaimId:
       name: OrganisationAuthorityClaimId
       description: The Authority claims ID for an organisation
@@ -51,13 +51,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityClaimId'
-    OrganisationAuthorisationId:
-      name: OrganisationAuthorisationId
+    OrganisationAuthorizationId:
+      name: OrganisationAuthorizationId
       description: The authorisation ID for an organisation's authority claims
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/OrganisationAuthorisationId'
+        $ref: '#/components/schemas/OrganisationAuthorizationId'
     CertificateOrKeyId:
       name: CertificateOrKeyId
       description: The certificate or key Id
@@ -121,27 +121,27 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/UserEmailId'
-    AuthorisationDomainName:
-      name: AuthorisationDomainName
-      description: Authorisation Domain Name. Eg:PSD2
+    AuthorizationDomainName:
+      name: AuthorizationDomainName
+      description: Authorization Domain Name. Eg:PSD2
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainName'
-    AuthorisationDomainRoleName:
-      name: AuthorisationDomainRoleName
-      description: Authorisation Domain Role Name. Eg:TPP
+        $ref: '#/components/schemas/AuthorizationDomainName'
+    AuthorizationDomainRoleName:
+      name: AuthorizationDomainRoleName
+      description: Authorization Domain Role Name. Eg:TPP
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainRoleName'
-    AuthorityAuthorisationDomainId:
-      name: AuthorityAuthorisationDomainId
-      description: ID of the Authority mapped with Authorisation Domain
+        $ref: '#/components/schemas/AuthorizationDomainRoleName'
+    AuthorityAuthorizationDomainId:
+      name: AuthorityAuthorizationDomainId
+      description: ID of the Authority mapped with Authorization Domain
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomainId'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomainId'
     OrganisationAuthorityDomainClaimId:
       name: OrganisationAuthorityDomainClaimId
       description: Organisation Authority Domain Claim Id
@@ -149,13 +149,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityDomainClaimId'
-    AuthorisationDomainUserId:
-      name: AuthorisationDomainUserId
+    AuthorizationDomainUserId:
+      name: AuthorizationDomainUserId
       description: Unique record Id to identify Domain User
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainUserId'
+        $ref: '#/components/schemas/AuthorizationDomainUserId'
     TnCId:
       name: TnCId
       description: Terms and Conditions unique identifier
@@ -202,13 +202,13 @@ components:
           schema:
             $ref: '#/components/schemas/AmendCertificateRequest'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       description: Properties to create/update authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServerRequest'
+            $ref: '#/components/schemas/AuthorizationServerRequest'
 
     OrganisationAuthorityClaimRequest:
       description: Properties to create/update authority claims
@@ -227,13 +227,13 @@ components:
             $ref: '#/components/schemas/UserUpdateRequest'
 
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       description: Properties to update/retrieve authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisationRequest'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizationRequest'
     ContactRequest:
       description: Properties to update contacts
       required: true
@@ -375,40 +375,40 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUserCreationRequest'
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       description: Admin user creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserCreateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserCreateRequest'
 
-    AuthorisationDomainRequest:
-      description: Authorisation Domain creation request
+    AuthorizationDomainRequest:
+      description: Authorization Domain creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRequest'
 
-    AuthorisationDomainRoleRequest:
-      description: Authorisation Domain Role creation request
+    AuthorizationDomainRoleRequest:
+      description: Authorization Domain Role creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoleRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRoleRequest'
 
-    AuthorityAuthorisationDomainRequest:
-      description: Authority Authorisation Domain mapping request
+    AuthorityAuthorizationDomainRequest:
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomainRequest'
 
     OrganisationAuthorityDomainClaimRequest:
-      description: Authority Authorisation Domain mapping request
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
@@ -467,12 +467,12 @@ components:
           schema:
             $ref: '#/components/schemas/EssSignRequest'
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       description: Request object to update a domain user
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserUpdateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserUpdateRequest'
 
   responses:
     NoContent:
@@ -510,33 +510,33 @@ components:
           schema:
             $ref: '#/components/schemas/OrganisationAuthorityClaim'
 
-    OrganisationAuthorityClaimAuthorisations:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorizations:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisations'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizations'
 
-    OrganisationAuthorityClaimAuthorisation:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorization:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    AuthorisationServers:
+    AuthorizationServers:
       description: All authorisation servers for the org
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServers'
+            $ref: '#/components/schemas/AuthorizationServers'
 
-    AuthorisationServer:
-      description: Authorisation server response
+    AuthorizationServer:
+      description: Authorization server response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServer'
+            $ref: '#/components/schemas/AuthorizationServer'
 
     CertificatesOrKeys:
       description: All certificates for the org
@@ -695,61 +695,61 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUser'
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       description: All users belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUsers'
+            $ref: '#/components/schemas/AuthorizationDomainUsers'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       description: User data belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUser'
+            $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       description: All data of authorisation domains mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomains'
+            $ref: '#/components/schemas/AuthorizationDomains'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       description: Data of an authorisation domain mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomain'
+            $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       description: All roles data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoles'
+            $ref: '#/components/schemas/AuthorizationDomainRoles'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       description: Role data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRole'
+            $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       description: All authority to domain mappings data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomains'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomains'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       description: Authority to domain mapping data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
     OrganisationAuthorityDomainClaims:
       description: All authority to domain mappings data
@@ -815,28 +815,28 @@ components:
             $ref: '#/components/schemas/OrganisationAdminUser'
 
     ApiResources:
-      description: Authorisation server Api Resources response
+      description: Authorization server Api Resources response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResources'
 
     ApiResource:
-      description: Authorisation server Api Resource response
+      description: Authorization server Api Resource response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResource'
 
     ApiDiscoveryEndpoints:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiDiscoveryEndpoints'
 
     ApiDiscoveryEndpoint:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
@@ -923,15 +923,15 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation Domain for the authority
+          description: Authorization Domain for the authority
           maxLength: 30
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
           maxLength: 30
-        Authorisations:
+        Authorizations:
           type: array
           items:
             type: object
@@ -970,12 +970,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Role for the authority
@@ -996,20 +996,20 @@ components:
       required:
         - RegistrationId
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - AuthorityId
         - Role
 
-    OrganisationAuthorityClaimAuthorisations:
+    OrganisationAuthorityClaimAuthorizations:
       type: array
       items:
-        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    OrganisationAuthorityClaimAuthorisation:
+    OrganisationAuthorityClaimAuthorization:
       type: object
       properties:
-        OrganisationAuthorisationId:
-          $ref: '#/components/schemas/OrganisationAuthorisationId'
+        OrganisationAuthorizationId:
+          $ref: '#/components/schemas/OrganisationAuthorizationId'
         OrganisationAuthorityClaimId:
           $ref: '#/components/schemas/OrganisationAuthorityClaimId'
         Status:
@@ -1024,7 +1024,7 @@ components:
           description: Abbreviated states information i.e. GB, IE, NL etc
           maxLength: 10
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       type: object
       properties:
         Status:
@@ -1045,16 +1045,16 @@ components:
         - Status
         - MemberState
 
-    AuthorisationServers:
+    AuthorizationServers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationServer'
+        $ref: '#/components/schemas/AuthorizationServer'
 
-    AuthorisationServer:
+    AuthorizationServer:
       type: object
       properties:
-        AuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        AuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
         OrganisationId:
           $ref: '#/components/schemas/OrganisationId'
         AutoRegistrationSupported:
@@ -1114,10 +1114,10 @@ components:
           type: string
           format: uri
           maxLength: 256
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       type: object
       properties:
         AutoRegistrationSupported:
@@ -1174,8 +1174,8 @@ components:
           type: string
           maxLength: 256
           x-required-message: PayloadSigningCertLocationUri must be provided
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
       required:
         - AutoRegistrationSupported
         - CustomerFriendlyName
@@ -1185,7 +1185,7 @@ components:
         - OpenIDDiscoveryDocument
         - PayloadSigningCertLocationUri
 
-    AuthorisationServerId:
+    AuthorizationServerId:
       type: string
       maxLength: 40
     CertificateOrKeyOrJWT:
@@ -1790,7 +1790,7 @@ components:
       minLength: 1
       maxLength: 40
 
-    OrganisationAuthorisationId:
+    OrganisationAuthorizationId:
       type: string
       description: Unique ID associated with authorisations for organisation's authority claims
       minLength: 1
@@ -1804,7 +1804,7 @@ components:
 
     AuthorityId:
       type: string
-      description: Unique ID associated with the Authorisation reference schema
+      description: Unique ID associated with the Authorization reference schema
       minLength: 1
       maxLength: 40
 
@@ -2014,8 +2014,8 @@ components:
           $ref: '#/components/schemas/Organisation'
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2106,8 +2106,8 @@ components:
           maxLength: 65535
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2389,9 +2389,9 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           maxLength: 30
         Role:
           type: string
@@ -2408,12 +2408,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
@@ -2422,7 +2422,7 @@ components:
           x-required-message: Role must be provided
       required:
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - Role
 
     SoftwareAuthorityClaimUpdateRequest:
@@ -2644,22 +2644,22 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainName:
+    AuthorizationDomainName:
       type: string
-      description: Authorisation Domain Name
+      description: Authorization Domain Name
       maxLength: 30
 
-    AuthorisationDomainRoleName:
+    AuthorizationDomainRoleName:
       type: string
-      description: Authorisation Domain Role Name
+      description: Authorization Domain Role Name
       maxLength: 30
 
-    AuthorityAuthorisationDomainId:
+    AuthorityAuthorizationDomainId:
       type: string
-      description: Mapping ID between Authority and Authorisation Domain
+      description: Mapping ID between Authority and Authorization Domain
       maxLength: 50
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       type: object
       properties:
         Email:
@@ -2667,7 +2667,7 @@ components:
           description: The user email address
           pattern: "^(.{1,}@[^.]{1,}).*"
           x-pattern-message: "EmailAddress must be a valid email"
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
           minLength: 1
@@ -2675,27 +2675,27 @@ components:
           $ref: '#/components/schemas/ContactRoleEnum'
       required:
         - Email
-        - AuthorisationDomainRole
+        - AuthorizationDomainRole
         - ContactRole
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainUser'
+        $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       type: object
       properties:
-        AuthorisationDomainUserId:
+        AuthorizationDomainUserId:
           type: string
           description: Unique record ID
         Email:
           type: string
           description: The user email address
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
           description: The authorisation domain for this user
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
         Status:
@@ -2714,42 +2714,42 @@ components:
             - PBC
             - SBC
 
-    AuthorisationDomainRequest:
+    AuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
           minLength: 2
           x-required-message: The authorisation domain region is mandatory
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
       required:
-        - AuthorisationDomainName
-        - AuthorisationDomainRegion
+        - AuthorizationDomainName
+        - AuthorizationDomainRegion
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomain'
+        $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
         Status:
@@ -2760,42 +2760,42 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainRoleRequest:
+    AuthorizationDomainRoleRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain role name is mandatory
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
       required:
-        - AuthorisationDomainRoleName
-        - AuthorisationDomainName
+        - AuthorizationDomainRoleName
+        - AuthorizationDomainName
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainRole'
+        $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
         Status:
@@ -2806,32 +2806,32 @@ components:
             - Inactive
           default: Active
 
-    AuthorityAuthorisationDomainRequest:
+    AuthorityAuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
       required:
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
           type: string
           description: The GUID of the Authority
-        AuthorityAuthorisationDomainId:
+        AuthorityAuthorizationDomainId:
           type: string
           description: The GUID of the Authority-Domain mapping
         Status:
@@ -2850,7 +2850,7 @@ components:
     OrganisationAuthorityDomainClaimRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
@@ -2865,7 +2865,7 @@ components:
           description: The registration ID
       required:
         - AuthorityId
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
     OrganisationAuthorityDomainClaims:
       type: array
@@ -2878,7 +2878,7 @@ components:
         OrganisationAuthorityDomainClaimId:
           type: string
           description: The unique org authority domain claim ID
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
@@ -2898,7 +2898,7 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainUserId:
+    AuthorizationDomainUserId:
       type: string
       description: Unique record ID to identify Domain user
       maxLength: 50
@@ -3152,9 +3152,9 @@ components:
     DomainRoleDetail:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
         Status:
           $ref: '#/components/schemas/StatusEnum'
@@ -3539,7 +3539,7 @@ components:
       type: string
       description: The envelope id of the ess signing request
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       type: object
       properties:
         Status:

--- a/documentation/source/versions/v1.0.0-rc6.3/swagger/swagger_resources_apis.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.3/swagger/swagger_resources_apis.yaml
@@ -140,7 +140,7 @@ components:
                   Available - Disponível
                   Unavailable - Indisponível
                   Temporarily Unavailable - Temporariamente Indisponível
-                  Pending Authorisation - Pendente de Autorização
+                  Pending Authorization - Pendente de Autorização
                 example: AVAILABLE
             additionalProperties: false
           minItems: 1

--- a/documentation/source/versions/v1.0.0-rc6.4/dictionary/resourcesGetResources_v1.csv
+++ b/documentation/source/versions/v1.0.0-rc6.4/dictionary/resourcesGetResources_v1.csv
@@ -20,7 +20,7 @@ INVOICE_FINANCING";1;1;"";Não permitido;string;ACCOUNT
 Available - Disponível
 Unavailable - Indisponível
 Temporarily Unavailable - Temporariamente Indisponível
-Pending Authorisation - Pendente de Autorização";Texto;;Obrigatório;;"AVAILABLE 
+Pending Authorization - Pendente de Autorização";Texto;;Obrigatório;;"AVAILABLE 
 UNAVAILABLE 
 TEMPORARILY_UNAVAILABLE 
 PENDING_AUTHORISATION";1;1;"";Não permitido;string;AVAILABLE

--- a/documentation/source/versions/v1.0.0-rc6.4/index.html
+++ b/documentation/source/versions/v1.0.0-rc6.4/index.html
@@ -1258,7 +1258,7 @@
                     <a href="#tocS_EnumAccountPaymentsType" class="toc-h2 toc-link" data-title="EnumAccountPaymentsType">EnumAccountPaymentsType</a>
                   </li>
                   <li>
-                    <a href="#tocS_EnumAuthorisationStatusType" class="toc-h2 toc-link" data-title="EnumAuthorisationStatusType">EnumAuthorisationStatusType</a>
+                    <a href="#tocS_EnumAuthorizationStatusType" class="toc-h2 toc-link" data-title="EnumAuthorizationStatusType">EnumAuthorizationStatusType</a>
                   </li>
                   <li>
                     <a href="#tocS_EnumPaymentPersonType" class="toc-h2 toc-link" data-title="EnumPaymentPersonType">EnumPaymentPersonType</a>
@@ -4264,7 +4264,7 @@ acesso e servidores de autorização no ambiente de sandbox e produção do Dire
 <li>Introdução</li>
 <li>Registrando um usuário no Diretório</li>
 <li>Acessando uma Organisation</li>
-<li>Cadastrando um Authorisation Server</li>
+<li>Cadastrando um Authorization Server</li>
 <li>Cadastrando Recursos de uma API</li>
 <li>Criando um Software Statements</li>
 <li>Criando uma solicitação de Assinatura de Certificado (CSR) em Sandbox</li>
@@ -4297,16 +4297,16 @@ directory/blob/main/openapi.yaml">https://github.com/OpenBanking-Brasil/specs-di
 <ul>
 <li>Organisations</li>
 <li>References - Authority</li>
-<li>References - Authorisation Domain</li>
-<li>References - Authorisation Domain Role</li>
-<li>References - Authority Authorisation Domain</li>
+<li>References - Authorization Domain</li>
+<li>References - Authorization Domain Role</li>
+<li>References - Authority Authorization Domain</li>
 <li>Organisation Authority Domain Claims</li>
 <li>Organisation Authority Claims</li>
-<li>Organisation Authority Claims Authorisations</li>
+<li>Organisation Authority Claims Authorizations</li>
 <li>Contacts</li>
-<li>Authorisation Servers</li>
-<li>Authorisation Servers - API Resources</li>
-<li>Authorisation Servers - API Discovery Endpoints</li>
+<li>Authorization Servers</li>
+<li>Authorization Servers - API Resources</li>
+<li>Authorization Servers - API Discovery Endpoints</li>
 <li>Software Statements</li>
 <li>Software Statement Authority Claims</li>
 <li>Software Statement Certificates</li>
@@ -16814,7 +16814,7 @@ This operation does not require authentication
 <td>» status</td>
 <td>string</td>
 <td>true</td>
-<td>Tipo de status de recurso (vide Enum):<br>Available - Disponível<br>Unavailable - Indisponível<br>Temporarily Unavailable - Temporariamente Indisponível<br>Pending Authorisation - Pendente de Autorização</td>
+<td>Tipo de status de recurso (vide Enum):<br>Available - Disponível<br>Unavailable - Indisponível<br>Temporarily Unavailable - Temporariamente Indisponível<br>Pending Authorization - Pendente de Autorização</td>
 </tr>
 <tr>
 <td>links</td>
@@ -33773,10 +33773,10 @@ TRAN - TransactingAccount - Conta de Pagamento pré-paga.</p>
 </tr>
 </tbody></table>
 
-<h2 id="tocS_EnumAuthorisationStatusType">EnumAuthorisationStatusType</h2>
+<h2 id="tocS_EnumAuthorizationStatusType">EnumAuthorizationStatusType</h2>
 
 <p><a id="schemaenumauthorisationstatustype"></a>
-<a id="schema_EnumAuthorisationStatusType"></a>
+<a id="schema_EnumAuthorizationStatusType"></a>
 <a id="tocSenumauthorisationstatustype"></a>
 <a id="tocsenumauthorisationstatustype"></a></p>
 
@@ -34819,7 +34819,7 @@ RJCT (REJECTED) - Instrução de pagamento rejeitada.</p>
 </tr>
 <tr>
 <td>» status</td>
-<td><a href="#schemaenumauthorisationstatustype">EnumAuthorisationStatusType</a></td>
+<td><a href="#schemaenumauthorisationstatustype">EnumAuthorizationStatusType</a></td>
 <td>true</td>
 <td>Retorna o estado do consentimento, o qual no momento de sua criação será AWAITING_AUTHORISATION.<br>Este estado será alterado depois da autorização do consentimento na detentora da conta do pagador (Debtor) para AUTHORISED ou REJECTED. <br>O consentimento fica no estado CONSUMED após ocorrer a iniciação do pagamento referente ao consentimento.  <br>Em caso de consentimento expirado a detentora deverá retornar o status REJECTED.  <br>Estados possíveis:  <br>AWAITING_AUTHORISATION - Aguardando autorização  <br>AUTHORISED - Autorizado   <br>REJECTED - Rejeitado  <br>CONSUMED - Consumido</td>
 </tr>
@@ -35237,7 +35237,7 @@ Espera-se que o detentor dos dados garanta que a medição do tempo de resposta 
 <td style="text-align: left">O Identificador do participante</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.CustomerFriendlyName</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.CustomerFriendlyName</strong></td>
 <td style="text-align: left">Nome da marca</td>
 </tr>
 <tr>
@@ -35257,19 +35257,19 @@ Espera-se que o detentor dos dados garanta que a medição do tempo de resposta 
 <td style="text-align: left">Status do papel</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIFamilyTipe</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIFamilyTipe</strong></td>
 <td style="text-align: left">URL das APIs</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIVersion</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIVersion</strong></td>
 <td style="text-align: left"></td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIEndPoint</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIEndPoint</strong></td>
 <td style="text-align: left"></td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.DeveloperPortalURI</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.DeveloperPortalURI</strong></td>
 <td style="text-align: left">URL da documentação sobre a API do participante</td>
 </tr>
 </tbody></table>

--- a/documentation/source/versions/v1.0.0-rc6.4/swagger/parts/schemas/enum/EnumResourceStatusType.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.4/swagger/parts/schemas/enum/EnumResourceStatusType.yaml
@@ -9,5 +9,5 @@ description: |
   Available - Disponível
   Unavailable - Indisponível
   Temporarily Unavailable - Temporariamente Indisponível
-  Pending Authorisation - Pendente de Autorização
+  Pending Authorization - Pendente de Autorização
 example: 'AVAILABLE'

--- a/documentation/source/versions/v1.0.0-rc6.4/swagger/parts/schemas/payments_apis/ResponsePaymentConsentData.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.4/swagger/parts/schemas/payments_apis/ResponsePaymentConsentData.yaml
@@ -33,7 +33,7 @@ properties:
     description: |
        Data e hora em que o recurso foi atualizado. Uma string com data e hora conforme especificação RFC-3339, sempre com a utilização de timezone UTC(UTC time format).
   status:
-    $ref: '../enum/EnumAuthorisationStatusType.yaml'
+    $ref: '../enum/EnumAuthorizationStatusType.yaml'
   creditor:
     $ref: ../payments_apis/PaymentIdentification.yaml
   payment:

--- a/documentation/source/versions/v1.0.0-rc6.4/swagger/swagger_open_banking_fase2_apis.yml
+++ b/documentation/source/versions/v1.0.0-rc6.4/swagger/swagger_open_banking_fase2_apis.yml
@@ -3246,7 +3246,7 @@ components:
                   Available - Disponível
                   Unavailable - Indisponível
                   Temporarily Unavailable - Temporariamente Indisponível
-                  Pending Authorisation - Pendente de Autorização
+                  Pending Authorization - Pendente de Autorização
                 example: AVAILABLE
             additionalProperties: false
           minItems: 1

--- a/documentation/source/versions/v1.0.0-rc6.4/swagger/swagger_open_banking_fase3_apis.yml
+++ b/documentation/source/versions/v1.0.0-rc6.4/swagger/swagger_open_banking_fase3_apis.yml
@@ -444,7 +444,7 @@ components:
         SLRY - Salary - Conta-Salário.  
         SVGS - Savings - Conta de Poupança.  
         TRAN - TransactingAccount - Conta de Pagamento pré-paga.
-    EnumAuthorisationStatusType:
+    EnumAuthorizationStatusType:
       type: string
       maxLength: 22
       enum:
@@ -921,7 +921,7 @@ components:
               description: |
                 Data e hora em que o recurso foi atualizado. Uma string com data e hora conforme especificação RFC-3339, sempre com a utilização de timezone UTC(UTC time format).
             status:
-              $ref: '#/components/schemas/EnumAuthorisationStatusType'
+              $ref: '#/components/schemas/EnumAuthorizationStatusType'
             creditor:
               $ref: '#/components/schemas/Identification'
             payment:

--- a/documentation/source/versions/v1.0.0-rc6.4/swagger/swagger_participants.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.4/swagger/swagger_participants.yaml
@@ -37,13 +37,13 @@ components:
       in: query
       schema:
         $ref: '#/components/schemas/PageableRequest'
-    AuthorisationServerId:
-      name: AuthorisationServerId
+    AuthorizationServerId:
+      name: AuthorizationServerId
       description: The authorisation server Id
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationServerId'
+        $ref: '#/components/schemas/AuthorizationServerId'
     OrganisationAuthorityClaimId:
       name: OrganisationAuthorityClaimId
       description: The Authority claims ID for an organisation
@@ -51,13 +51,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityClaimId'
-    OrganisationAuthorisationId:
-      name: OrganisationAuthorisationId
+    OrganisationAuthorizationId:
+      name: OrganisationAuthorizationId
       description: The authorisation ID for an organisation's authority claims
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/OrganisationAuthorisationId'
+        $ref: '#/components/schemas/OrganisationAuthorizationId'
     CertificateOrKeyId:
       name: CertificateOrKeyId
       description: The certificate or key Id
@@ -121,27 +121,27 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/UserEmailId'
-    AuthorisationDomainName:
-      name: AuthorisationDomainName
-      description: Authorisation Domain Name. Eg:PSD2
+    AuthorizationDomainName:
+      name: AuthorizationDomainName
+      description: Authorization Domain Name. Eg:PSD2
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainName'
-    AuthorisationDomainRoleName:
-      name: AuthorisationDomainRoleName
-      description: Authorisation Domain Role Name. Eg:TPP
+        $ref: '#/components/schemas/AuthorizationDomainName'
+    AuthorizationDomainRoleName:
+      name: AuthorizationDomainRoleName
+      description: Authorization Domain Role Name. Eg:TPP
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainRoleName'
-    AuthorityAuthorisationDomainId:
-      name: AuthorityAuthorisationDomainId
-      description: ID of the Authority mapped with Authorisation Domain
+        $ref: '#/components/schemas/AuthorizationDomainRoleName'
+    AuthorityAuthorizationDomainId:
+      name: AuthorityAuthorizationDomainId
+      description: ID of the Authority mapped with Authorization Domain
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomainId'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomainId'
     OrganisationAuthorityDomainClaimId:
       name: OrganisationAuthorityDomainClaimId
       description: Organisation Authority Domain Claim Id
@@ -149,13 +149,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityDomainClaimId'
-    AuthorisationDomainUserId:
-      name: AuthorisationDomainUserId
+    AuthorizationDomainUserId:
+      name: AuthorizationDomainUserId
       description: Unique record Id to identify Domain User
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainUserId'
+        $ref: '#/components/schemas/AuthorizationDomainUserId'
     TnCId:
       name: TnCId
       description: Terms and Conditions unique identifier
@@ -202,13 +202,13 @@ components:
           schema:
             $ref: '#/components/schemas/AmendCertificateRequest'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       description: Properties to create/update authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServerRequest'
+            $ref: '#/components/schemas/AuthorizationServerRequest'
 
     OrganisationAuthorityClaimRequest:
       description: Properties to create/update authority claims
@@ -227,13 +227,13 @@ components:
             $ref: '#/components/schemas/UserUpdateRequest'
 
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       description: Properties to update/retrieve authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisationRequest'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizationRequest'
     ContactRequest:
       description: Properties to update contacts
       required: true
@@ -375,40 +375,40 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUserCreationRequest'
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       description: Admin user creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserCreateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserCreateRequest'
 
-    AuthorisationDomainRequest:
-      description: Authorisation Domain creation request
+    AuthorizationDomainRequest:
+      description: Authorization Domain creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRequest'
 
-    AuthorisationDomainRoleRequest:
-      description: Authorisation Domain Role creation request
+    AuthorizationDomainRoleRequest:
+      description: Authorization Domain Role creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoleRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRoleRequest'
 
-    AuthorityAuthorisationDomainRequest:
-      description: Authority Authorisation Domain mapping request
+    AuthorityAuthorizationDomainRequest:
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomainRequest'
 
     OrganisationAuthorityDomainClaimRequest:
-      description: Authority Authorisation Domain mapping request
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
@@ -467,12 +467,12 @@ components:
           schema:
             $ref: '#/components/schemas/EssSignRequest'
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       description: Request object to update a domain user
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserUpdateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserUpdateRequest'
 
   responses:
     NoContent:
@@ -510,33 +510,33 @@ components:
           schema:
             $ref: '#/components/schemas/OrganisationAuthorityClaim'
 
-    OrganisationAuthorityClaimAuthorisations:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorizations:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisations'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizations'
 
-    OrganisationAuthorityClaimAuthorisation:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorization:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    AuthorisationServers:
+    AuthorizationServers:
       description: All authorisation servers for the org
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServers'
+            $ref: '#/components/schemas/AuthorizationServers'
 
-    AuthorisationServer:
-      description: Authorisation server response
+    AuthorizationServer:
+      description: Authorization server response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServer'
+            $ref: '#/components/schemas/AuthorizationServer'
 
     CertificatesOrKeys:
       description: All certificates for the org
@@ -695,61 +695,61 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUser'
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       description: All users belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUsers'
+            $ref: '#/components/schemas/AuthorizationDomainUsers'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       description: User data belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUser'
+            $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       description: All data of authorisation domains mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomains'
+            $ref: '#/components/schemas/AuthorizationDomains'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       description: Data of an authorisation domain mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomain'
+            $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       description: All roles data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoles'
+            $ref: '#/components/schemas/AuthorizationDomainRoles'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       description: Role data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRole'
+            $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       description: All authority to domain mappings data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomains'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomains'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       description: Authority to domain mapping data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
     OrganisationAuthorityDomainClaims:
       description: All authority to domain mappings data
@@ -815,28 +815,28 @@ components:
             $ref: '#/components/schemas/OrganisationAdminUser'
 
     ApiResources:
-      description: Authorisation server Api Resources response
+      description: Authorization server Api Resources response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResources'
 
     ApiResource:
-      description: Authorisation server Api Resource response
+      description: Authorization server Api Resource response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResource'
 
     ApiDiscoveryEndpoints:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiDiscoveryEndpoints'
 
     ApiDiscoveryEndpoint:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
@@ -923,15 +923,15 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation Domain for the authority
+          description: Authorization Domain for the authority
           maxLength: 30
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
           maxLength: 30
-        Authorisations:
+        Authorizations:
           type: array
           items:
             type: object
@@ -970,12 +970,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Role for the authority
@@ -996,20 +996,20 @@ components:
       required:
         - RegistrationId
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - AuthorityId
         - Role
 
-    OrganisationAuthorityClaimAuthorisations:
+    OrganisationAuthorityClaimAuthorizations:
       type: array
       items:
-        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    OrganisationAuthorityClaimAuthorisation:
+    OrganisationAuthorityClaimAuthorization:
       type: object
       properties:
-        OrganisationAuthorisationId:
-          $ref: '#/components/schemas/OrganisationAuthorisationId'
+        OrganisationAuthorizationId:
+          $ref: '#/components/schemas/OrganisationAuthorizationId'
         OrganisationAuthorityClaimId:
           $ref: '#/components/schemas/OrganisationAuthorityClaimId'
         Status:
@@ -1024,7 +1024,7 @@ components:
           description: Abbreviated states information i.e. GB, IE, NL etc
           maxLength: 10
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       type: object
       properties:
         Status:
@@ -1045,16 +1045,16 @@ components:
         - Status
         - MemberState
 
-    AuthorisationServers:
+    AuthorizationServers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationServer'
+        $ref: '#/components/schemas/AuthorizationServer'
 
-    AuthorisationServer:
+    AuthorizationServer:
       type: object
       properties:
-        AuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        AuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
         OrganisationId:
           $ref: '#/components/schemas/OrganisationId'
         AutoRegistrationSupported:
@@ -1114,10 +1114,10 @@ components:
           type: string
           format: uri
           maxLength: 256
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       type: object
       properties:
         AutoRegistrationSupported:
@@ -1174,8 +1174,8 @@ components:
           type: string
           maxLength: 256
           x-required-message: PayloadSigningCertLocationUri must be provided
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
       required:
         - AutoRegistrationSupported
         - CustomerFriendlyName
@@ -1185,7 +1185,7 @@ components:
         - OpenIDDiscoveryDocument
         - PayloadSigningCertLocationUri
 
-    AuthorisationServerId:
+    AuthorizationServerId:
       type: string
       maxLength: 40
     CertificateOrKeyOrJWT:
@@ -1790,7 +1790,7 @@ components:
       minLength: 1
       maxLength: 40
 
-    OrganisationAuthorisationId:
+    OrganisationAuthorizationId:
       type: string
       description: Unique ID associated with authorisations for organisation's authority claims
       minLength: 1
@@ -1804,7 +1804,7 @@ components:
 
     AuthorityId:
       type: string
-      description: Unique ID associated with the Authorisation reference schema
+      description: Unique ID associated with the Authorization reference schema
       minLength: 1
       maxLength: 40
 
@@ -2014,8 +2014,8 @@ components:
           $ref: '#/components/schemas/Organisation'
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2106,8 +2106,8 @@ components:
           maxLength: 65535
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2389,9 +2389,9 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           maxLength: 30
         Role:
           type: string
@@ -2408,12 +2408,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
@@ -2422,7 +2422,7 @@ components:
           x-required-message: Role must be provided
       required:
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - Role
 
     SoftwareAuthorityClaimUpdateRequest:
@@ -2644,22 +2644,22 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainName:
+    AuthorizationDomainName:
       type: string
-      description: Authorisation Domain Name
+      description: Authorization Domain Name
       maxLength: 30
 
-    AuthorisationDomainRoleName:
+    AuthorizationDomainRoleName:
       type: string
-      description: Authorisation Domain Role Name
+      description: Authorization Domain Role Name
       maxLength: 30
 
-    AuthorityAuthorisationDomainId:
+    AuthorityAuthorizationDomainId:
       type: string
-      description: Mapping ID between Authority and Authorisation Domain
+      description: Mapping ID between Authority and Authorization Domain
       maxLength: 50
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       type: object
       properties:
         Email:
@@ -2667,7 +2667,7 @@ components:
           description: The user email address
           pattern: "^(.{1,}@[^.]{1,}).*"
           x-pattern-message: "EmailAddress must be a valid email"
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
           minLength: 1
@@ -2675,27 +2675,27 @@ components:
           $ref: '#/components/schemas/ContactRoleEnum'
       required:
         - Email
-        - AuthorisationDomainRole
+        - AuthorizationDomainRole
         - ContactRole
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainUser'
+        $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       type: object
       properties:
-        AuthorisationDomainUserId:
+        AuthorizationDomainUserId:
           type: string
           description: Unique record ID
         Email:
           type: string
           description: The user email address
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
           description: The authorisation domain for this user
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
         Status:
@@ -2714,42 +2714,42 @@ components:
             - PBC
             - SBC
 
-    AuthorisationDomainRequest:
+    AuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
           minLength: 2
           x-required-message: The authorisation domain region is mandatory
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
       required:
-        - AuthorisationDomainName
-        - AuthorisationDomainRegion
+        - AuthorizationDomainName
+        - AuthorizationDomainRegion
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomain'
+        $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
         Status:
@@ -2760,42 +2760,42 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainRoleRequest:
+    AuthorizationDomainRoleRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain role name is mandatory
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
       required:
-        - AuthorisationDomainRoleName
-        - AuthorisationDomainName
+        - AuthorizationDomainRoleName
+        - AuthorizationDomainName
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainRole'
+        $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
         Status:
@@ -2806,32 +2806,32 @@ components:
             - Inactive
           default: Active
 
-    AuthorityAuthorisationDomainRequest:
+    AuthorityAuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
       required:
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
           type: string
           description: The GUID of the Authority
-        AuthorityAuthorisationDomainId:
+        AuthorityAuthorizationDomainId:
           type: string
           description: The GUID of the Authority-Domain mapping
         Status:
@@ -2850,7 +2850,7 @@ components:
     OrganisationAuthorityDomainClaimRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
@@ -2865,7 +2865,7 @@ components:
           description: The registration ID
       required:
         - AuthorityId
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
     OrganisationAuthorityDomainClaims:
       type: array
@@ -2878,7 +2878,7 @@ components:
         OrganisationAuthorityDomainClaimId:
           type: string
           description: The unique org authority domain claim ID
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
@@ -2898,7 +2898,7 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainUserId:
+    AuthorizationDomainUserId:
       type: string
       description: Unique record ID to identify Domain user
       maxLength: 50
@@ -3152,9 +3152,9 @@ components:
     DomainRoleDetail:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
         Status:
           $ref: '#/components/schemas/StatusEnum'
@@ -3539,7 +3539,7 @@ components:
       type: string
       description: The envelope id of the ess signing request
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       type: object
       properties:
         Status:

--- a/documentation/source/versions/v1.0.0-rc6.4/swagger/swagger_resources_apis.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.4/swagger/swagger_resources_apis.yaml
@@ -140,7 +140,7 @@ components:
                   Available - Disponível
                   Unavailable - Indisponível
                   Temporarily Unavailable - Temporariamente Indisponível
-                  Pending Authorisation - Pendente de Autorização
+                  Pending Authorization - Pendente de Autorização
                 example: AVAILABLE
             additionalProperties: false
           minItems: 1

--- a/documentation/source/versions/v1.0.0-rc6.5/dictionary/resourcesGetResources_v1.csv
+++ b/documentation/source/versions/v1.0.0-rc6.5/dictionary/resourcesGetResources_v1.csv
@@ -20,7 +20,7 @@ INVOICE_FINANCING";1;1;"";Não permitido;string;ACCOUNT
 Available - Disponível
 Unavailable - Indisponível
 Temporarily Unavailable - Temporariamente Indisponível
-Pending Authorisation - Pendente de Autorização";Texto;;Obrigatório;;"AVAILABLE 
+Pending Authorization - Pendente de Autorização";Texto;;Obrigatório;;"AVAILABLE 
 UNAVAILABLE 
 TEMPORARILY_UNAVAILABLE 
 PENDING_AUTHORISATION";1;1;"";Não permitido;string;AVAILABLE

--- a/documentation/source/versions/v1.0.0-rc6.5/index.html
+++ b/documentation/source/versions/v1.0.0-rc6.5/index.html
@@ -1315,7 +1315,7 @@
                     <a href="#tocS_EnumAccountPaymentsType" class="toc-h2 toc-link" data-title="EnumAccountPaymentsType">EnumAccountPaymentsType</a>
                   </li>
                   <li>
-                    <a href="#tocS_EnumAuthorisationStatusType" class="toc-h2 toc-link" data-title="EnumAuthorisationStatusType">EnumAuthorisationStatusType</a>
+                    <a href="#tocS_EnumAuthorizationStatusType" class="toc-h2 toc-link" data-title="EnumAuthorizationStatusType">EnumAuthorizationStatusType</a>
                   </li>
                   <li>
                     <a href="#tocS_EnumPaymentPersonType" class="toc-h2 toc-link" data-title="EnumPaymentPersonType">EnumPaymentPersonType</a>
@@ -4326,7 +4326,7 @@ acesso e servidores de autorização no ambiente de sandbox e produção do Dire
 <li>Introdução</li>
 <li>Registrando um usuário no Diretório</li>
 <li>Acessando uma Organisation</li>
-<li>Cadastrando um Authorisation Server</li>
+<li>Cadastrando um Authorization Server</li>
 <li>Cadastrando Recursos de uma API</li>
 <li>Criando um Software Statements</li>
 <li>Criando uma solicitação de Assinatura de Certificado (CSR) em Sandbox</li>
@@ -4359,16 +4359,16 @@ directory/blob/main/openapi.yaml">https://github.com/OpenBanking-Brasil/specs-di
 <ul>
 <li>Organisations</li>
 <li>References - Authority</li>
-<li>References - Authorisation Domain</li>
-<li>References - Authorisation Domain Role</li>
-<li>References - Authority Authorisation Domain</li>
+<li>References - Authorization Domain</li>
+<li>References - Authorization Domain Role</li>
+<li>References - Authority Authorization Domain</li>
 <li>Organisation Authority Domain Claims</li>
 <li>Organisation Authority Claims</li>
-<li>Organisation Authority Claims Authorisations</li>
+<li>Organisation Authority Claims Authorizations</li>
 <li>Contacts</li>
-<li>Authorisation Servers</li>
-<li>Authorisation Servers - API Resources</li>
-<li>Authorisation Servers - API Discovery Endpoints</li>
+<li>Authorization Servers</li>
+<li>Authorization Servers - API Resources</li>
+<li>Authorization Servers - API Discovery Endpoints</li>
 <li>Software Statements</li>
 <li>Software Statement Authority Claims</li>
 <li>Software Statement Certificates</li>
@@ -16612,7 +16612,7 @@ This operation does not require authentication
 <td>» status</td>
 <td>string</td>
 <td>true</td>
-<td>Tipo de status de recurso (vide Enum):<br>Available - Disponível<br>Unavailable - Indisponível<br>Temporarily Unavailable - Temporariamente Indisponível<br>Pending Authorisation - Pendente de Autorização</td>
+<td>Tipo de status de recurso (vide Enum):<br>Available - Disponível<br>Unavailable - Indisponível<br>Temporarily Unavailable - Temporariamente Indisponível<br>Pending Authorization - Pendente de Autorização</td>
 </tr>
 <tr>
 <td>links</td>
@@ -33571,10 +33571,10 @@ TRAN - TransactingAccount - Conta de Pagamento pré-paga.</p>
 </tr>
 </tbody></table>
 
-<h2 id="tocS_EnumAuthorisationStatusType">EnumAuthorisationStatusType</h2>
+<h2 id="tocS_EnumAuthorizationStatusType">EnumAuthorizationStatusType</h2>
 
 <p><a id="schemaenumauthorisationstatustype"></a>
-<a id="schema_EnumAuthorisationStatusType"></a>
+<a id="schema_EnumAuthorizationStatusType"></a>
 <a id="tocSenumauthorisationstatustype"></a>
 <a id="tocsenumauthorisationstatustype"></a></p>
 
@@ -34617,7 +34617,7 @@ RJCT (REJECTED) - Instrução de pagamento rejeitada.</p>
 </tr>
 <tr>
 <td>» status</td>
-<td><a href="#schemaenumauthorisationstatustype">EnumAuthorisationStatusType</a></td>
+<td><a href="#schemaenumauthorisationstatustype">EnumAuthorizationStatusType</a></td>
 <td>true</td>
 <td>Retorna o estado do consentimento, o qual no momento de sua criação será AWAITING_AUTHORISATION.<br>Este estado será alterado depois da autorização do consentimento na detentora da conta do pagador (Debtor) para AUTHORISED ou REJECTED. <br>O consentimento fica no estado CONSUMED após ocorrer a iniciação do pagamento referente ao consentimento.  <br>Em caso de consentimento expirado a detentora deverá retornar o status REJECTED.  <br>Estados possíveis:  <br>AWAITING_AUTHORISATION - Aguardando autorização  <br>AUTHORISED - Autorizado   <br>REJECTED - Rejeitado  <br>CONSUMED - Consumido</td>
 </tr>
@@ -35035,7 +35035,7 @@ Espera-se que o detentor dos dados garanta que a medição do tempo de resposta 
 <td style="text-align: left">O Identificador do participante</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.CustomerFriendlyName</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.CustomerFriendlyName</strong></td>
 <td style="text-align: left">Nome da marca</td>
 </tr>
 <tr>
@@ -35055,19 +35055,19 @@ Espera-se que o detentor dos dados garanta que a medição do tempo de resposta 
 <td style="text-align: left">Status do papel</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIFamilyTipe</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIFamilyTipe</strong></td>
 <td style="text-align: left">URL das APIs</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIVersion</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIVersion</strong></td>
 <td style="text-align: left"></td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIEndPoint</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIEndPoint</strong></td>
 <td style="text-align: left"></td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.DeveloperPortalURI</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.DeveloperPortalURI</strong></td>
 <td style="text-align: left">URL da documentação sobre a API do participante</td>
 </tr>
 </tbody></table>

--- a/documentation/source/versions/v1.0.0-rc6.5/swagger/parts/schemas/enum/EnumResourceStatusType.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.5/swagger/parts/schemas/enum/EnumResourceStatusType.yaml
@@ -9,5 +9,5 @@ description: |
   Available - Disponível
   Unavailable - Indisponível
   Temporarily Unavailable - Temporariamente Indisponível
-  Pending Authorisation - Pendente de Autorização
+  Pending Authorization - Pendente de Autorização
 example: 'AVAILABLE'

--- a/documentation/source/versions/v1.0.0-rc6.5/swagger/parts/schemas/payments_apis/ResponsePaymentConsentData.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.5/swagger/parts/schemas/payments_apis/ResponsePaymentConsentData.yaml
@@ -33,7 +33,7 @@ properties:
     description: |
        Data e hora em que o recurso foi atualizado. Uma string com data e hora conforme especificação RFC-3339, sempre com a utilização de timezone UTC(UTC time format).
   status:
-    $ref: '../enum/EnumAuthorisationStatusType.yaml'
+    $ref: '../enum/EnumAuthorizationStatusType.yaml'
   creditor:
     $ref: ../payments_apis/PaymentIdentification.yaml
   payment:

--- a/documentation/source/versions/v1.0.0-rc6.5/swagger/swagger_open_banking_fase2_apis.yml
+++ b/documentation/source/versions/v1.0.0-rc6.5/swagger/swagger_open_banking_fase2_apis.yml
@@ -3213,7 +3213,7 @@ components:
                   Available - Disponível
                   Unavailable - Indisponível
                   Temporarily Unavailable - Temporariamente Indisponível
-                  Pending Authorisation - Pendente de Autorização
+                  Pending Authorization - Pendente de Autorização
                 example: AVAILABLE
             additionalProperties: false
           minItems: 1

--- a/documentation/source/versions/v1.0.0-rc6.5/swagger/swagger_open_banking_fase3_apis.yml
+++ b/documentation/source/versions/v1.0.0-rc6.5/swagger/swagger_open_banking_fase3_apis.yml
@@ -444,7 +444,7 @@ components:
         SLRY - Salary - Conta-Salário.  
         SVGS - Savings - Conta de Poupança.  
         TRAN - TransactingAccount - Conta de Pagamento pré-paga.
-    EnumAuthorisationStatusType:
+    EnumAuthorizationStatusType:
       type: string
       maxLength: 22
       enum:
@@ -921,7 +921,7 @@ components:
               description: |
                 Data e hora em que o recurso foi atualizado. Uma string com data e hora conforme especificação RFC-3339, sempre com a utilização de timezone UTC(UTC time format).
             status:
-              $ref: '#/components/schemas/EnumAuthorisationStatusType'
+              $ref: '#/components/schemas/EnumAuthorizationStatusType'
             creditor:
               $ref: '#/components/schemas/Identification'
             payment:

--- a/documentation/source/versions/v1.0.0-rc6.5/swagger/swagger_participants.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.5/swagger/swagger_participants.yaml
@@ -37,13 +37,13 @@ components:
       in: query
       schema:
         $ref: '#/components/schemas/PageableRequest'
-    AuthorisationServerId:
-      name: AuthorisationServerId
+    AuthorizationServerId:
+      name: AuthorizationServerId
       description: The authorisation server Id
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationServerId'
+        $ref: '#/components/schemas/AuthorizationServerId'
     OrganisationAuthorityClaimId:
       name: OrganisationAuthorityClaimId
       description: The Authority claims ID for an organisation
@@ -51,13 +51,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityClaimId'
-    OrganisationAuthorisationId:
-      name: OrganisationAuthorisationId
+    OrganisationAuthorizationId:
+      name: OrganisationAuthorizationId
       description: The authorisation ID for an organisation's authority claims
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/OrganisationAuthorisationId'
+        $ref: '#/components/schemas/OrganisationAuthorizationId'
     CertificateOrKeyId:
       name: CertificateOrKeyId
       description: The certificate or key Id
@@ -121,27 +121,27 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/UserEmailId'
-    AuthorisationDomainName:
-      name: AuthorisationDomainName
-      description: Authorisation Domain Name. Eg:PSD2
+    AuthorizationDomainName:
+      name: AuthorizationDomainName
+      description: Authorization Domain Name. Eg:PSD2
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainName'
-    AuthorisationDomainRoleName:
-      name: AuthorisationDomainRoleName
-      description: Authorisation Domain Role Name. Eg:TPP
+        $ref: '#/components/schemas/AuthorizationDomainName'
+    AuthorizationDomainRoleName:
+      name: AuthorizationDomainRoleName
+      description: Authorization Domain Role Name. Eg:TPP
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainRoleName'
-    AuthorityAuthorisationDomainId:
-      name: AuthorityAuthorisationDomainId
-      description: ID of the Authority mapped with Authorisation Domain
+        $ref: '#/components/schemas/AuthorizationDomainRoleName'
+    AuthorityAuthorizationDomainId:
+      name: AuthorityAuthorizationDomainId
+      description: ID of the Authority mapped with Authorization Domain
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomainId'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomainId'
     OrganisationAuthorityDomainClaimId:
       name: OrganisationAuthorityDomainClaimId
       description: Organisation Authority Domain Claim Id
@@ -149,13 +149,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityDomainClaimId'
-    AuthorisationDomainUserId:
-      name: AuthorisationDomainUserId
+    AuthorizationDomainUserId:
+      name: AuthorizationDomainUserId
       description: Unique record Id to identify Domain User
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainUserId'
+        $ref: '#/components/schemas/AuthorizationDomainUserId'
     TnCId:
       name: TnCId
       description: Terms and Conditions unique identifier
@@ -202,13 +202,13 @@ components:
           schema:
             $ref: '#/components/schemas/AmendCertificateRequest'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       description: Properties to create/update authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServerRequest'
+            $ref: '#/components/schemas/AuthorizationServerRequest'
 
     OrganisationAuthorityClaimRequest:
       description: Properties to create/update authority claims
@@ -227,13 +227,13 @@ components:
             $ref: '#/components/schemas/UserUpdateRequest'
 
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       description: Properties to update/retrieve authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisationRequest'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizationRequest'
     ContactRequest:
       description: Properties to update contacts
       required: true
@@ -375,40 +375,40 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUserCreationRequest'
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       description: Admin user creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserCreateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserCreateRequest'
 
-    AuthorisationDomainRequest:
-      description: Authorisation Domain creation request
+    AuthorizationDomainRequest:
+      description: Authorization Domain creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRequest'
 
-    AuthorisationDomainRoleRequest:
-      description: Authorisation Domain Role creation request
+    AuthorizationDomainRoleRequest:
+      description: Authorization Domain Role creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoleRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRoleRequest'
 
-    AuthorityAuthorisationDomainRequest:
-      description: Authority Authorisation Domain mapping request
+    AuthorityAuthorizationDomainRequest:
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomainRequest'
 
     OrganisationAuthorityDomainClaimRequest:
-      description: Authority Authorisation Domain mapping request
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
@@ -467,12 +467,12 @@ components:
           schema:
             $ref: '#/components/schemas/EssSignRequest'
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       description: Request object to update a domain user
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserUpdateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserUpdateRequest'
 
   responses:
     NoContent:
@@ -510,33 +510,33 @@ components:
           schema:
             $ref: '#/components/schemas/OrganisationAuthorityClaim'
 
-    OrganisationAuthorityClaimAuthorisations:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorizations:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisations'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizations'
 
-    OrganisationAuthorityClaimAuthorisation:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorization:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    AuthorisationServers:
+    AuthorizationServers:
       description: All authorisation servers for the org
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServers'
+            $ref: '#/components/schemas/AuthorizationServers'
 
-    AuthorisationServer:
-      description: Authorisation server response
+    AuthorizationServer:
+      description: Authorization server response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServer'
+            $ref: '#/components/schemas/AuthorizationServer'
 
     CertificatesOrKeys:
       description: All certificates for the org
@@ -695,61 +695,61 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUser'
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       description: All users belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUsers'
+            $ref: '#/components/schemas/AuthorizationDomainUsers'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       description: User data belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUser'
+            $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       description: All data of authorisation domains mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomains'
+            $ref: '#/components/schemas/AuthorizationDomains'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       description: Data of an authorisation domain mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomain'
+            $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       description: All roles data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoles'
+            $ref: '#/components/schemas/AuthorizationDomainRoles'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       description: Role data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRole'
+            $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       description: All authority to domain mappings data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomains'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomains'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       description: Authority to domain mapping data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
     OrganisationAuthorityDomainClaims:
       description: All authority to domain mappings data
@@ -815,28 +815,28 @@ components:
             $ref: '#/components/schemas/OrganisationAdminUser'
 
     ApiResources:
-      description: Authorisation server Api Resources response
+      description: Authorization server Api Resources response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResources'
 
     ApiResource:
-      description: Authorisation server Api Resource response
+      description: Authorization server Api Resource response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResource'
 
     ApiDiscoveryEndpoints:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiDiscoveryEndpoints'
 
     ApiDiscoveryEndpoint:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
@@ -923,15 +923,15 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation Domain for the authority
+          description: Authorization Domain for the authority
           maxLength: 30
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
           maxLength: 30
-        Authorisations:
+        Authorizations:
           type: array
           items:
             type: object
@@ -970,12 +970,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Role for the authority
@@ -996,20 +996,20 @@ components:
       required:
         - RegistrationId
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - AuthorityId
         - Role
 
-    OrganisationAuthorityClaimAuthorisations:
+    OrganisationAuthorityClaimAuthorizations:
       type: array
       items:
-        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    OrganisationAuthorityClaimAuthorisation:
+    OrganisationAuthorityClaimAuthorization:
       type: object
       properties:
-        OrganisationAuthorisationId:
-          $ref: '#/components/schemas/OrganisationAuthorisationId'
+        OrganisationAuthorizationId:
+          $ref: '#/components/schemas/OrganisationAuthorizationId'
         OrganisationAuthorityClaimId:
           $ref: '#/components/schemas/OrganisationAuthorityClaimId'
         Status:
@@ -1024,7 +1024,7 @@ components:
           description: Abbreviated states information i.e. GB, IE, NL etc
           maxLength: 10
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       type: object
       properties:
         Status:
@@ -1045,16 +1045,16 @@ components:
         - Status
         - MemberState
 
-    AuthorisationServers:
+    AuthorizationServers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationServer'
+        $ref: '#/components/schemas/AuthorizationServer'
 
-    AuthorisationServer:
+    AuthorizationServer:
       type: object
       properties:
-        AuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        AuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
         OrganisationId:
           $ref: '#/components/schemas/OrganisationId'
         AutoRegistrationSupported:
@@ -1114,10 +1114,10 @@ components:
           type: string
           format: uri
           maxLength: 256
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       type: object
       properties:
         AutoRegistrationSupported:
@@ -1174,8 +1174,8 @@ components:
           type: string
           maxLength: 256
           x-required-message: PayloadSigningCertLocationUri must be provided
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
       required:
         - AutoRegistrationSupported
         - CustomerFriendlyName
@@ -1185,7 +1185,7 @@ components:
         - OpenIDDiscoveryDocument
         - PayloadSigningCertLocationUri
 
-    AuthorisationServerId:
+    AuthorizationServerId:
       type: string
       maxLength: 40
     CertificateOrKeyOrJWT:
@@ -1790,7 +1790,7 @@ components:
       minLength: 1
       maxLength: 40
 
-    OrganisationAuthorisationId:
+    OrganisationAuthorizationId:
       type: string
       description: Unique ID associated with authorisations for organisation's authority claims
       minLength: 1
@@ -1804,7 +1804,7 @@ components:
 
     AuthorityId:
       type: string
-      description: Unique ID associated with the Authorisation reference schema
+      description: Unique ID associated with the Authorization reference schema
       minLength: 1
       maxLength: 40
 
@@ -2014,8 +2014,8 @@ components:
           $ref: '#/components/schemas/Organisation'
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2106,8 +2106,8 @@ components:
           maxLength: 65535
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2389,9 +2389,9 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           maxLength: 30
         Role:
           type: string
@@ -2408,12 +2408,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
@@ -2422,7 +2422,7 @@ components:
           x-required-message: Role must be provided
       required:
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - Role
 
     SoftwareAuthorityClaimUpdateRequest:
@@ -2644,22 +2644,22 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainName:
+    AuthorizationDomainName:
       type: string
-      description: Authorisation Domain Name
+      description: Authorization Domain Name
       maxLength: 30
 
-    AuthorisationDomainRoleName:
+    AuthorizationDomainRoleName:
       type: string
-      description: Authorisation Domain Role Name
+      description: Authorization Domain Role Name
       maxLength: 30
 
-    AuthorityAuthorisationDomainId:
+    AuthorityAuthorizationDomainId:
       type: string
-      description: Mapping ID between Authority and Authorisation Domain
+      description: Mapping ID between Authority and Authorization Domain
       maxLength: 50
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       type: object
       properties:
         Email:
@@ -2667,7 +2667,7 @@ components:
           description: The user email address
           pattern: "^(.{1,}@[^.]{1,}).*"
           x-pattern-message: "EmailAddress must be a valid email"
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
           minLength: 1
@@ -2675,27 +2675,27 @@ components:
           $ref: '#/components/schemas/ContactRoleEnum'
       required:
         - Email
-        - AuthorisationDomainRole
+        - AuthorizationDomainRole
         - ContactRole
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainUser'
+        $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       type: object
       properties:
-        AuthorisationDomainUserId:
+        AuthorizationDomainUserId:
           type: string
           description: Unique record ID
         Email:
           type: string
           description: The user email address
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
           description: The authorisation domain for this user
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
         Status:
@@ -2714,42 +2714,42 @@ components:
             - PBC
             - SBC
 
-    AuthorisationDomainRequest:
+    AuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
           minLength: 2
           x-required-message: The authorisation domain region is mandatory
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
       required:
-        - AuthorisationDomainName
-        - AuthorisationDomainRegion
+        - AuthorizationDomainName
+        - AuthorizationDomainRegion
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomain'
+        $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
         Status:
@@ -2760,42 +2760,42 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainRoleRequest:
+    AuthorizationDomainRoleRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain role name is mandatory
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
       required:
-        - AuthorisationDomainRoleName
-        - AuthorisationDomainName
+        - AuthorizationDomainRoleName
+        - AuthorizationDomainName
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainRole'
+        $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
         Status:
@@ -2806,32 +2806,32 @@ components:
             - Inactive
           default: Active
 
-    AuthorityAuthorisationDomainRequest:
+    AuthorityAuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
       required:
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
           type: string
           description: The GUID of the Authority
-        AuthorityAuthorisationDomainId:
+        AuthorityAuthorizationDomainId:
           type: string
           description: The GUID of the Authority-Domain mapping
         Status:
@@ -2850,7 +2850,7 @@ components:
     OrganisationAuthorityDomainClaimRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
@@ -2865,7 +2865,7 @@ components:
           description: The registration ID
       required:
         - AuthorityId
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
     OrganisationAuthorityDomainClaims:
       type: array
@@ -2878,7 +2878,7 @@ components:
         OrganisationAuthorityDomainClaimId:
           type: string
           description: The unique org authority domain claim ID
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
@@ -2898,7 +2898,7 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainUserId:
+    AuthorizationDomainUserId:
       type: string
       description: Unique record ID to identify Domain user
       maxLength: 50
@@ -3152,9 +3152,9 @@ components:
     DomainRoleDetail:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
         Status:
           $ref: '#/components/schemas/StatusEnum'
@@ -3539,7 +3539,7 @@ components:
       type: string
       description: The envelope id of the ess signing request
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       type: object
       properties:
         Status:

--- a/documentation/source/versions/v1.0.0-rc6.5/swagger/swagger_resources_apis.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.5/swagger/swagger_resources_apis.yaml
@@ -142,7 +142,7 @@ components:
                   Available - Disponível
                   Unavailable - Indisponível
                   Temporarily Unavailable - Temporariamente Indisponível
-                  Pending Authorisation - Pendente de Autorização
+                  Pending Authorization - Pendente de Autorização
                 example: AVAILABLE
             additionalProperties: false
           minItems: 1

--- a/documentation/source/versions/v1.0.0-rc6.6/dictionary/resourcesGetResources_v1.csv
+++ b/documentation/source/versions/v1.0.0-rc6.6/dictionary/resourcesGetResources_v1.csv
@@ -20,7 +20,7 @@ INVOICE_FINANCING";1;1;"";Não permitido;string;ACCOUNT
 Available - Disponível
 Unavailable - Indisponível
 Temporarily Unavailable - Temporariamente Indisponível
-Pending Authorisation - Pendente de Autorização";Texto;;Obrigatório;;"AVAILABLE 
+Pending Authorization - Pendente de Autorização";Texto;;Obrigatório;;"AVAILABLE 
 UNAVAILABLE 
 TEMPORARILY_UNAVAILABLE 
 PENDING_AUTHORISATION";1;1;"";Não permitido;string;AVAILABLE

--- a/documentation/source/versions/v1.0.0-rc6.6/index.html
+++ b/documentation/source/versions/v1.0.0-rc6.6/index.html
@@ -1284,7 +1284,7 @@
                     <a href="#tocS_EnumAccountPaymentsType" class="toc-h2 toc-link" data-title="EnumAccountPaymentsType">EnumAccountPaymentsType</a>
                   </li>
                   <li>
-                    <a href="#tocS_EnumAuthorisationStatusType" class="toc-h2 toc-link" data-title="EnumAuthorisationStatusType">EnumAuthorisationStatusType</a>
+                    <a href="#tocS_EnumAuthorizationStatusType" class="toc-h2 toc-link" data-title="EnumAuthorizationStatusType">EnumAuthorizationStatusType</a>
                   </li>
                   <li>
                     <a href="#tocS_EnumPaymentPersonType" class="toc-h2 toc-link" data-title="EnumPaymentPersonType">EnumPaymentPersonType</a>
@@ -3309,7 +3309,7 @@ acesso e servidores de autorização no ambiente de sandbox e produção do Dire
 <li>Introdução</li>
 <li>Registrando um usuário no Diretório</li>
 <li>Acessando uma Organisation</li>
-<li>Cadastrando um Authorisation Server</li>
+<li>Cadastrando um Authorization Server</li>
 <li>Cadastrando Recursos de uma API</li>
 <li>Criando um Software Statements</li>
 <li>Criando uma solicitação de Assinatura de Certificado (CSR) em Sandbox</li>
@@ -3342,16 +3342,16 @@ directory/blob/main/openapi.yaml">https://github.com/OpenBanking-Brasil/specs-di
 <ul>
 <li>Organisations</li>
 <li>References - Authority</li>
-<li>References - Authorisation Domain</li>
-<li>References - Authorisation Domain Role</li>
-<li>References - Authority Authorisation Domain</li>
+<li>References - Authorization Domain</li>
+<li>References - Authorization Domain Role</li>
+<li>References - Authority Authorization Domain</li>
 <li>Organisation Authority Domain Claims</li>
 <li>Organisation Authority Claims</li>
-<li>Organisation Authority Claims Authorisations</li>
+<li>Organisation Authority Claims Authorizations</li>
 <li>Contacts</li>
-<li>Authorisation Servers</li>
-<li>Authorisation Servers - API Resources</li>
-<li>Authorisation Servers - API Discovery Endpoints</li>
+<li>Authorization Servers</li>
+<li>Authorization Servers - API Resources</li>
+<li>Authorization Servers - API Discovery Endpoints</li>
 <li>Software Statements</li>
 <li>Software Statement Authority Claims</li>
 <li>Software Statement Certificates</li>
@@ -15624,7 +15624,7 @@ This operation does not require authentication
 <td>» status</td>
 <td>string</td>
 <td>true</td>
-<td>Tipo de status de recurso (vide Enum):<br>Available - Disponível<br>Unavailable - Indisponível<br>Temporarily Unavailable - Temporariamente Indisponível<br>Pending Authorisation - Pendente de Autorização</td>
+<td>Tipo de status de recurso (vide Enum):<br>Available - Disponível<br>Unavailable - Indisponível<br>Temporarily Unavailable - Temporariamente Indisponível<br>Pending Authorization - Pendente de Autorização</td>
 </tr>
 <tr>
 <td>links</td>
@@ -32599,10 +32599,10 @@ TRAN - TransactingAccount - Conta de Pagamento pré-paga.</p>
 </tr>
 </tbody></table>
 
-<h2 id="tocS_EnumAuthorisationStatusType">EnumAuthorisationStatusType</h2>
+<h2 id="tocS_EnumAuthorizationStatusType">EnumAuthorizationStatusType</h2>
 
 <p><a id="schemaenumauthorisationstatustype"></a>
-<a id="schema_EnumAuthorisationStatusType"></a>
+<a id="schema_EnumAuthorizationStatusType"></a>
 <a id="tocSenumauthorisationstatustype"></a>
 <a id="tocsenumauthorisationstatustype"></a></p>
 
@@ -33645,7 +33645,7 @@ RJCT (REJECTED) - Instrução de pagamento rejeitada.</p>
 </tr>
 <tr>
 <td>» status</td>
-<td><a href="#schemaenumauthorisationstatustype">EnumAuthorisationStatusType</a></td>
+<td><a href="#schemaenumauthorisationstatustype">EnumAuthorizationStatusType</a></td>
 <td>true</td>
 <td>Retorna o estado do consentimento, o qual no momento de sua criação será AWAITING_AUTHORISATION.<br>Este estado será alterado depois da autorização do consentimento na detentora da conta do pagador (Debtor) para AUTHORISED ou REJECTED. <br>O consentimento fica no estado CONSUMED após ocorrer a iniciação do pagamento referente ao consentimento.  <br>Em caso de consentimento expirado a detentora deverá retornar o status REJECTED.  <br>Estados possíveis:  <br>AWAITING_AUTHORISATION - Aguardando autorização  <br>AUTHORISED - Autorizado   <br>REJECTED - Rejeitado  <br>CONSUMED - Consumido</td>
 </tr>
@@ -34063,7 +34063,7 @@ Espera-se que o detentor dos dados garanta que a medição do tempo de resposta 
 <td style="text-align: left">O Identificador do participante</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.CustomerFriendlyName</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.CustomerFriendlyName</strong></td>
 <td style="text-align: left">Nome da marca</td>
 </tr>
 <tr>
@@ -34083,19 +34083,19 @@ Espera-se que o detentor dos dados garanta que a medição do tempo de resposta 
 <td style="text-align: left">Status do papel</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIFamilyTipe</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIFamilyTipe</strong></td>
 <td style="text-align: left">URL das APIs</td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIVersion</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIVersion</strong></td>
 <td style="text-align: left"></td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.APIResources.APIEndPoint</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.APIResources.APIEndPoint</strong></td>
 <td style="text-align: left"></td>
 </tr>
 <tr>
-<td style="text-align: left"><strong>AuthorisationServers.DeveloperPortalURI</strong></td>
+<td style="text-align: left"><strong>AuthorizationServers.DeveloperPortalURI</strong></td>
 <td style="text-align: left">URL da documentação sobre a API do participante</td>
 </tr>
 </tbody></table>

--- a/documentation/source/versions/v1.0.0-rc6.6/swagger/parts/schemas/enum/EnumResourceStatusType.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.6/swagger/parts/schemas/enum/EnumResourceStatusType.yaml
@@ -9,5 +9,5 @@ description: |
   Available - Disponível
   Unavailable - Indisponível
   Temporarily Unavailable - Temporariamente Indisponível
-  Pending Authorisation - Pendente de Autorização
+  Pending Authorization - Pendente de Autorização
 example: 'AVAILABLE'

--- a/documentation/source/versions/v1.0.0-rc6.6/swagger/parts/schemas/payments_apis/ResponsePaymentConsentData.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.6/swagger/parts/schemas/payments_apis/ResponsePaymentConsentData.yaml
@@ -33,7 +33,7 @@ properties:
     description: |
        Data e hora em que o recurso foi atualizado. Uma string com data e hora conforme especificação RFC-3339, sempre com a utilização de timezone UTC(UTC time format).
   status:
-    $ref: '../enum/EnumAuthorisationStatusType.yaml'
+    $ref: '../enum/EnumAuthorizationStatusType.yaml'
   creditor:
     $ref: ../payments_apis/PaymentIdentification.yaml
   payment:

--- a/documentation/source/versions/v1.0.0-rc6.6/swagger/swagger_open_banking_fase2_apis.yml
+++ b/documentation/source/versions/v1.0.0-rc6.6/swagger/swagger_open_banking_fase2_apis.yml
@@ -3221,7 +3221,7 @@ components:
                   Available - Disponível
                   Unavailable - Indisponível
                   Temporarily Unavailable - Temporariamente Indisponível
-                  Pending Authorisation - Pendente de Autorização
+                  Pending Authorization - Pendente de Autorização
                 example: AVAILABLE
             additionalProperties: false
           minItems: 1

--- a/documentation/source/versions/v1.0.0-rc6.6/swagger/swagger_open_banking_fase3_apis.yml
+++ b/documentation/source/versions/v1.0.0-rc6.6/swagger/swagger_open_banking_fase3_apis.yml
@@ -444,7 +444,7 @@ components:
         SLRY - Salary - Conta-Salário.  
         SVGS - Savings - Conta de Poupança.  
         TRAN - TransactingAccount - Conta de Pagamento pré-paga.
-    EnumAuthorisationStatusType:
+    EnumAuthorizationStatusType:
       type: string
       maxLength: 22
       enum:
@@ -921,7 +921,7 @@ components:
               description: |
                 Data e hora em que o recurso foi atualizado. Uma string com data e hora conforme especificação RFC-3339, sempre com a utilização de timezone UTC(UTC time format).
             status:
-              $ref: '#/components/schemas/EnumAuthorisationStatusType'
+              $ref: '#/components/schemas/EnumAuthorizationStatusType'
             creditor:
               $ref: '#/components/schemas/Identification'
             payment:

--- a/documentation/source/versions/v1.0.0-rc6.6/swagger/swagger_participants.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.6/swagger/swagger_participants.yaml
@@ -37,13 +37,13 @@ components:
       in: query
       schema:
         $ref: '#/components/schemas/PageableRequest'
-    AuthorisationServerId:
-      name: AuthorisationServerId
+    AuthorizationServerId:
+      name: AuthorizationServerId
       description: The authorisation server Id
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationServerId'
+        $ref: '#/components/schemas/AuthorizationServerId'
     OrganisationAuthorityClaimId:
       name: OrganisationAuthorityClaimId
       description: The Authority claims ID for an organisation
@@ -51,13 +51,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityClaimId'
-    OrganisationAuthorisationId:
-      name: OrganisationAuthorisationId
+    OrganisationAuthorizationId:
+      name: OrganisationAuthorizationId
       description: The authorisation ID for an organisation's authority claims
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/OrganisationAuthorisationId'
+        $ref: '#/components/schemas/OrganisationAuthorizationId'
     CertificateOrKeyId:
       name: CertificateOrKeyId
       description: The certificate or key Id
@@ -121,27 +121,27 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/UserEmailId'
-    AuthorisationDomainName:
-      name: AuthorisationDomainName
-      description: Authorisation Domain Name. Eg:PSD2
+    AuthorizationDomainName:
+      name: AuthorizationDomainName
+      description: Authorization Domain Name. Eg:PSD2
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainName'
-    AuthorisationDomainRoleName:
-      name: AuthorisationDomainRoleName
-      description: Authorisation Domain Role Name. Eg:TPP
+        $ref: '#/components/schemas/AuthorizationDomainName'
+    AuthorizationDomainRoleName:
+      name: AuthorizationDomainRoleName
+      description: Authorization Domain Role Name. Eg:TPP
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainRoleName'
-    AuthorityAuthorisationDomainId:
-      name: AuthorityAuthorisationDomainId
-      description: ID of the Authority mapped with Authorisation Domain
+        $ref: '#/components/schemas/AuthorizationDomainRoleName'
+    AuthorityAuthorizationDomainId:
+      name: AuthorityAuthorizationDomainId
+      description: ID of the Authority mapped with Authorization Domain
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomainId'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomainId'
     OrganisationAuthorityDomainClaimId:
       name: OrganisationAuthorityDomainClaimId
       description: Organisation Authority Domain Claim Id
@@ -149,13 +149,13 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/OrganisationAuthorityDomainClaimId'
-    AuthorisationDomainUserId:
-      name: AuthorisationDomainUserId
+    AuthorizationDomainUserId:
+      name: AuthorizationDomainUserId
       description: Unique record Id to identify Domain User
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/AuthorisationDomainUserId'
+        $ref: '#/components/schemas/AuthorizationDomainUserId'
     TnCId:
       name: TnCId
       description: Terms and Conditions unique identifier
@@ -202,13 +202,13 @@ components:
           schema:
             $ref: '#/components/schemas/AmendCertificateRequest'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       description: Properties to create/update authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServerRequest'
+            $ref: '#/components/schemas/AuthorizationServerRequest'
 
     OrganisationAuthorityClaimRequest:
       description: Properties to create/update authority claims
@@ -227,13 +227,13 @@ components:
             $ref: '#/components/schemas/UserUpdateRequest'
 
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       description: Properties to update/retrieve authorisation server
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisationRequest'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizationRequest'
     ContactRequest:
       description: Properties to update contacts
       required: true
@@ -375,40 +375,40 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUserCreationRequest'
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       description: Admin user creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserCreateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserCreateRequest'
 
-    AuthorisationDomainRequest:
-      description: Authorisation Domain creation request
+    AuthorizationDomainRequest:
+      description: Authorization Domain creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRequest'
 
-    AuthorisationDomainRoleRequest:
-      description: Authorisation Domain Role creation request
+    AuthorizationDomainRoleRequest:
+      description: Authorization Domain Role creation request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoleRequest'
+            $ref: '#/components/schemas/AuthorizationDomainRoleRequest'
 
-    AuthorityAuthorisationDomainRequest:
-      description: Authority Authorisation Domain mapping request
+    AuthorityAuthorizationDomainRequest:
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomainRequest'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomainRequest'
 
     OrganisationAuthorityDomainClaimRequest:
-      description: Authority Authorisation Domain mapping request
+      description: Authority Authorization Domain mapping request
       required: true
       content:
         application/json:
@@ -467,12 +467,12 @@ components:
           schema:
             $ref: '#/components/schemas/EssSignRequest'
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       description: Request object to update a domain user
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUserUpdateRequest'
+            $ref: '#/components/schemas/AuthorizationDomainUserUpdateRequest'
 
   responses:
     NoContent:
@@ -510,33 +510,33 @@ components:
           schema:
             $ref: '#/components/schemas/OrganisationAuthorityClaim'
 
-    OrganisationAuthorityClaimAuthorisations:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorizations:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisations'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorizations'
 
-    OrganisationAuthorityClaimAuthorisation:
-      description: Authorisations response
+    OrganisationAuthorityClaimAuthorization:
+      description: Authorizations response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+            $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    AuthorisationServers:
+    AuthorizationServers:
       description: All authorisation servers for the org
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServers'
+            $ref: '#/components/schemas/AuthorizationServers'
 
-    AuthorisationServer:
-      description: Authorisation server response
+    AuthorizationServer:
+      description: Authorization server response
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationServer'
+            $ref: '#/components/schemas/AuthorizationServer'
 
     CertificatesOrKeys:
       description: All certificates for the org
@@ -695,61 +695,61 @@ components:
           schema:
             $ref: '#/components/schemas/SuperUser'
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       description: All users belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUsers'
+            $ref: '#/components/schemas/AuthorizationDomainUsers'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       description: User data belonging to an authorisation domain
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainUser'
+            $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       description: All data of authorisation domains mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomains'
+            $ref: '#/components/schemas/AuthorizationDomains'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       description: Data of an authorisation domain mapped to an authority
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomain'
+            $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       description: All roles data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRoles'
+            $ref: '#/components/schemas/AuthorizationDomainRoles'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       description: Role data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorisationDomainRole'
+            $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       description: All authority to domain mappings data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomains'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomains'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       description: Authority to domain mapping data
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+            $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
     OrganisationAuthorityDomainClaims:
       description: All authority to domain mappings data
@@ -815,28 +815,28 @@ components:
             $ref: '#/components/schemas/OrganisationAdminUser'
 
     ApiResources:
-      description: Authorisation server Api Resources response
+      description: Authorization server Api Resources response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResources'
 
     ApiResource:
-      description: Authorisation server Api Resource response
+      description: Authorization server Api Resource response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiResource'
 
     ApiDiscoveryEndpoints:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ApiDiscoveryEndpoints'
 
     ApiDiscoveryEndpoint:
-      description: Authorisation server response
+      description: Authorization server response
       content:
         application/json:
           schema:
@@ -923,15 +923,15 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation Domain for the authority
+          description: Authorization Domain for the authority
           maxLength: 30
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
           maxLength: 30
-        Authorisations:
+        Authorizations:
           type: array
           items:
             type: object
@@ -970,12 +970,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Role for the authority
@@ -996,20 +996,20 @@ components:
       required:
         - RegistrationId
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - AuthorityId
         - Role
 
-    OrganisationAuthorityClaimAuthorisations:
+    OrganisationAuthorityClaimAuthorizations:
       type: array
       items:
-        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorisation'
+        $ref: '#/components/schemas/OrganisationAuthorityClaimAuthorization'
 
-    OrganisationAuthorityClaimAuthorisation:
+    OrganisationAuthorityClaimAuthorization:
       type: object
       properties:
-        OrganisationAuthorisationId:
-          $ref: '#/components/schemas/OrganisationAuthorisationId'
+        OrganisationAuthorizationId:
+          $ref: '#/components/schemas/OrganisationAuthorizationId'
         OrganisationAuthorityClaimId:
           $ref: '#/components/schemas/OrganisationAuthorityClaimId'
         Status:
@@ -1024,7 +1024,7 @@ components:
           description: Abbreviated states information i.e. GB, IE, NL etc
           maxLength: 10
 
-    OrganisationAuthorityClaimAuthorisationRequest:
+    OrganisationAuthorityClaimAuthorizationRequest:
       type: object
       properties:
         Status:
@@ -1045,16 +1045,16 @@ components:
         - Status
         - MemberState
 
-    AuthorisationServers:
+    AuthorizationServers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationServer'
+        $ref: '#/components/schemas/AuthorizationServer'
 
-    AuthorisationServer:
+    AuthorizationServer:
       type: object
       properties:
-        AuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        AuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
         OrganisationId:
           $ref: '#/components/schemas/OrganisationId'
         AutoRegistrationSupported:
@@ -1114,10 +1114,10 @@ components:
           type: string
           format: uri
           maxLength: 256
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
 
-    AuthorisationServerRequest:
+    AuthorizationServerRequest:
       type: object
       properties:
         AutoRegistrationSupported:
@@ -1174,8 +1174,8 @@ components:
           type: string
           maxLength: 256
           x-required-message: PayloadSigningCertLocationUri must be provided
-        ParentAuthorisationServerId:
-          $ref: '#/components/schemas/AuthorisationServerId'
+        ParentAuthorizationServerId:
+          $ref: '#/components/schemas/AuthorizationServerId'
       required:
         - AutoRegistrationSupported
         - CustomerFriendlyName
@@ -1185,7 +1185,7 @@ components:
         - OpenIDDiscoveryDocument
         - PayloadSigningCertLocationUri
 
-    AuthorisationServerId:
+    AuthorizationServerId:
       type: string
       maxLength: 40
     CertificateOrKeyOrJWT:
@@ -1790,7 +1790,7 @@ components:
       minLength: 1
       maxLength: 40
 
-    OrganisationAuthorisationId:
+    OrganisationAuthorizationId:
       type: string
       description: Unique ID associated with authorisations for organisation's authority claims
       minLength: 1
@@ -1804,7 +1804,7 @@ components:
 
     AuthorityId:
       type: string
-      description: Unique ID associated with the Authorisation reference schema
+      description: Unique ID associated with the Authorization reference schema
       minLength: 1
       maxLength: 40
 
@@ -2014,8 +2014,8 @@ components:
           $ref: '#/components/schemas/Organisation'
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2106,8 +2106,8 @@ components:
           maxLength: 65535
         Contacts:
           $ref: '#/components/schemas/Contacts'
-        AuthorisationServers:
-          $ref: '#/components/schemas/AuthorisationServers'
+        AuthorizationServers:
+          $ref: '#/components/schemas/AuthorizationServers'
         OrgDomainClaims:
           $ref: '#/components/schemas/OrganisationAuthorityDomainClaims'
         OrgDomainRoleClaims:
@@ -2389,9 +2389,9 @@ components:
             - Active
             - Inactive
           default: Active
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           maxLength: 30
         Role:
           type: string
@@ -2408,12 +2408,12 @@ components:
             - Inactive
           default: Active
           x-required-message: Status must be provided
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
-          description: Authorisation domain for the authority
+          description: Authorization domain for the authority
           minLength: 1
           maxLength: 30
-          x-required-message: AuthorisationDomain must be provided
+          x-required-message: AuthorizationDomain must be provided
         Role:
           type: string
           description: Roles for the Authority i.e. ASPSP, AISP, PISP, CBPII
@@ -2422,7 +2422,7 @@ components:
           x-required-message: Role must be provided
       required:
         - Status
-        - AuthorisationDomain
+        - AuthorizationDomain
         - Role
 
     SoftwareAuthorityClaimUpdateRequest:
@@ -2644,22 +2644,22 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainName:
+    AuthorizationDomainName:
       type: string
-      description: Authorisation Domain Name
+      description: Authorization Domain Name
       maxLength: 30
 
-    AuthorisationDomainRoleName:
+    AuthorizationDomainRoleName:
       type: string
-      description: Authorisation Domain Role Name
+      description: Authorization Domain Role Name
       maxLength: 30
 
-    AuthorityAuthorisationDomainId:
+    AuthorityAuthorizationDomainId:
       type: string
-      description: Mapping ID between Authority and Authorisation Domain
+      description: Mapping ID between Authority and Authorization Domain
       maxLength: 50
 
-    AuthorisationDomainUserCreateRequest:
+    AuthorizationDomainUserCreateRequest:
       type: object
       properties:
         Email:
@@ -2667,7 +2667,7 @@ components:
           description: The user email address
           pattern: "^(.{1,}@[^.]{1,}).*"
           x-pattern-message: "EmailAddress must be a valid email"
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
           minLength: 1
@@ -2675,27 +2675,27 @@ components:
           $ref: '#/components/schemas/ContactRoleEnum'
       required:
         - Email
-        - AuthorisationDomainRole
+        - AuthorizationDomainRole
         - ContactRole
 
-    AuthorisationDomainUsers:
+    AuthorizationDomainUsers:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainUser'
+        $ref: '#/components/schemas/AuthorizationDomainUser'
 
-    AuthorisationDomainUser:
+    AuthorizationDomainUser:
       type: object
       properties:
-        AuthorisationDomainUserId:
+        AuthorizationDomainUserId:
           type: string
           description: Unique record ID
         Email:
           type: string
           description: The user email address
-        AuthorisationDomain:
+        AuthorizationDomain:
           type: string
           description: The authorisation domain for this user
-        AuthorisationDomainRole:
+        AuthorizationDomainRole:
           type: string
           description: The authorisation domain role for this user
         Status:
@@ -2714,42 +2714,42 @@ components:
             - PBC
             - SBC
 
-    AuthorisationDomainRequest:
+    AuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
           minLength: 2
           x-required-message: The authorisation domain region is mandatory
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
       required:
-        - AuthorisationDomainName
-        - AuthorisationDomainRegion
+        - AuthorizationDomainName
+        - AuthorizationDomainRegion
 
-    AuthorisationDomains:
+    AuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomain'
+        $ref: '#/components/schemas/AuthorizationDomain'
 
-    AuthorisationDomain:
+    AuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRegion:
+        AuthorizationDomainRegion:
           type: string
           description: The authorisation domain region
-        AuthorisationDomainDescription:
+        AuthorizationDomainDescription:
           type: string
           description: The authorisation domain description
         Status:
@@ -2760,42 +2760,42 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainRoleRequest:
+    AuthorizationDomainRoleRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role name
           minLength: 1
           maxLength: 30
           x-required-message: The authorisation domain role name is mandatory
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
       required:
-        - AuthorisationDomainRoleName
-        - AuthorisationDomainName
+        - AuthorizationDomainRoleName
+        - AuthorizationDomainName
 
-    AuthorisationDomainRoles:
+    AuthorizationDomainRoles:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorisationDomainRole'
+        $ref: '#/components/schemas/AuthorizationDomainRole'
 
-    AuthorisationDomainRole:
+    AuthorizationDomainRole:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
           description: The authorisation domain role
-        AuthorisationDomainRoleDescription:
+        AuthorizationDomainRoleDescription:
           type: string
           description: The authorisation domain role description
         Status:
@@ -2806,32 +2806,32 @@ components:
             - Inactive
           default: Active
 
-    AuthorityAuthorisationDomainRequest:
+    AuthorityAuthorizationDomainRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
           x-required-message: The authorisation domain name is mandatory
       required:
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
-    AuthorityAuthorisationDomains:
+    AuthorityAuthorizationDomains:
       type: array
       items:
-        $ref: '#/components/schemas/AuthorityAuthorisationDomain'
+        $ref: '#/components/schemas/AuthorityAuthorizationDomain'
 
-    AuthorityAuthorisationDomain:
+    AuthorityAuthorizationDomain:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
           type: string
           description: The GUID of the Authority
-        AuthorityAuthorisationDomainId:
+        AuthorityAuthorizationDomainId:
           type: string
           description: The GUID of the Authority-Domain mapping
         Status:
@@ -2850,7 +2850,7 @@ components:
     OrganisationAuthorityDomainClaimRequest:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
           minLength: 1
@@ -2865,7 +2865,7 @@ components:
           description: The registration ID
       required:
         - AuthorityId
-        - AuthorisationDomainName
+        - AuthorizationDomainName
 
     OrganisationAuthorityDomainClaims:
       type: array
@@ -2878,7 +2878,7 @@ components:
         OrganisationAuthorityDomainClaimId:
           type: string
           description: The unique org authority domain claim ID
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
           description: The authorisation domain name
         AuthorityId:
@@ -2898,7 +2898,7 @@ components:
             - Inactive
           default: Active
 
-    AuthorisationDomainUserId:
+    AuthorizationDomainUserId:
       type: string
       description: Unique record ID to identify Domain user
       maxLength: 50
@@ -3152,9 +3152,9 @@ components:
     DomainRoleDetail:
       type: object
       properties:
-        AuthorisationDomainName:
+        AuthorizationDomainName:
           type: string
-        AuthorisationDomainRoleName:
+        AuthorizationDomainRoleName:
           type: string
         Status:
           $ref: '#/components/schemas/StatusEnum'
@@ -3539,7 +3539,7 @@ components:
       type: string
       description: The envelope id of the ess signing request
 
-    AuthorisationDomainUserUpdateRequest:
+    AuthorizationDomainUserUpdateRequest:
       type: object
       properties:
         Status:

--- a/documentation/source/versions/v1.0.0-rc6.6/swagger/swagger_resources_apis.yaml
+++ b/documentation/source/versions/v1.0.0-rc6.6/swagger/swagger_resources_apis.yaml
@@ -142,7 +142,7 @@ components:
                   Available - Disponível
                   Unavailable - Indisponível
                   Temporarily Unavailable - Temporariamente Indisponível
-                  Pending Authorisation - Pendente de Autorização
+                  Pending Authorization - Pendente de Autorização
                 example: AVAILABLE
             additionalProperties: false
           minItems: 1


### PR DESCRIPTION
since my last PR was closed without any comment, i believe it was mistake, so im reopening it. 
please provide some info if you guys decide to not merge this...

looks like a lot of schemas / documents are spelling Authorisation with
an `s`. A quick search revealed that this is a cultural british thing:

```
While many people in the UK prefer the 's' (and some will make a fuss about 'z' being "American"), both forms are recognised in the UK, and the Oxford Dictionaries (which are widely taken as authorities) prefer 'z'.
```

since some examples in the docs are mentioning Authorization with `z`
and HTTP RFCs are using `z` aswell, i think it's better for us to do
this refactoring to prevent confusion in the future.

```
4.2.  Authorization

   The "Authorization" header field allows a user agent to authenticate
   itself with an origin server -- usually, but not necessarily, after
   receiving a 401 (Unauthorized) response.  Its value consists of
   credentials containing the authentication information of the user
   agent for the realm of the resource being requested.

     Authorization = credentials

   If a request is authenticated and a realm specified, the same
   credentials are presumed to be valid for all other requests within
   this realm (assuming that the authentication scheme itself does not
   require otherwise, such as credentials that vary according to a
   challenge value or using synchronized clocks).

   A proxy forwarding a request MUST NOT modify any Authorization fields
   in that request.  See Section 3.2 of [RFC7234] for details of and
   requirements pertaining to handling of the Authorization field by
   HTTP caches.
```
https://tools.ietf.org/html/rfc7235#section-4.2