### PR TITLE
remove currency from CreditCardAccountsLimitsData

### DIFF
--- a/documentation/source/swagger/parts/schemas/credit_cards_apis/CreditCardAccountsLimitsData.yaml
+++ b/documentation/source/swagger/parts/schemas/credit_cards_apis/CreditCardAccountsLimitsData.yaml
@@ -1,7 +1,6 @@
 type: object
 description: Conjunto de informações referentes aos limites da conta de pagamento pós-paga.
 required:
-  - currency
   - creditLineLimitType
   - consolidationType
   - identificationNumber


### PR DESCRIPTION
currency appears as required but it's not defined in
CreditCardAccountsLimitsData schema, looks like we can simply remove
this