### PR TITLE
fix: atualiza lista de schema da fase 2

### DIFF
--- a/documentation/source/swagger/parts/_open_banking_fase2_apis_part.yml
+++ b/documentation/source/swagger/parts/_open_banking_fase2_apis_part.yml
@@ -3374,6 +3374,8 @@ components:
       $ref: ./schemas/unarranged_account_overdraft_apis/UnarrangedAccountOverdraftReleases.yaml
     UnarrangedAccountOverdraftTaxesOverParcel:
       $ref: ./schemas/unarranged_account_overdraft_apis/UnarrangedAccountOverdraftTaxesOverParcel.yaml
+    UnarrangedAccountsOverdraftContractedWarranty:
+      $ref: ./schemas/unarranged_account_overdraft_apis/UnarrangedAccountsOverdraftContractedWarranty.yaml
   parameters:
     consentId:
       $ref: ./parameters/ConsentId.yaml


### PR DESCRIPTION
Add `UnarrangedAccountsOverdraftContractedWarranty` na lista de esquemas da fase 2.

Essa informação está faltando, por isso não há referência na documentação, conforme imagem abaixo:

![image](https://user-images.githubusercontent.com/1793185/143294312-0e08003b-fdb7-4751-bc13-2be5ea6885b4.png)