### PR TITLE
Sinalizar versão 'RC' na API de Investimentos 

### DIFF
--- a/documentation/source/swagger/parts/_open_banking_fase4_apis_part.yml
+++ b/documentation/source/swagger/parts/_open_banking_fase4_apis_part.yml
@@ -11,7 +11,7 @@ tags:
     description: |
       |Versão|
       |:-----|
-      |1.0.0|
+      |1.0.0-rc1.0|
 
       #### Visão Geral
 


### PR DESCRIPTION
Ajustar versão da API de Investimentos para sinalizar que é uma versão Release Candidate (RC).